### PR TITLE
Solve problems with xmpp, hipchat and irc modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,3 @@ as needed.
 * Step 2: Push the container up: `docker push stackstorm/hubot:<VER>`
   * Use the same tag specified in Step 1.
 * Step 3: Profit
-
-### TODO
-
-This is currently under dev. The following adapters are still needed:
-
-* XMPP
-* Hipchat
-* IRC
-
-Problems with Node v4 are causing issues. Under investigation.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "hubot-scripts"     : "^2.16.2",
     "hubot-stackstorm"  : "^0.2.5",
     "hubot-flowdock"    : "^0.7.6",
+    "hubot-xmpp"        : "git+https://github.com/markstory/hubot-xmpp.git#94c3438e42778c53e38f6909939c514da50a0dca",
+    "hubot-hipchat"     : "git+https://github.com/StackStorm/hubot-hipchat#sonnyp-patch",
+    "hubot-irc"         : "git+https://github.com/nandub/hubot-irc#51d1f4b418fc039a456b7891c7f9bf836699cfdc",
     "hubot-slack"       : "^3.4.2"
   },
   "engines": {


### PR DESCRIPTION
- hubot-xmpp is pending till https://github.com/markstory/hubot-xmpp/milestones/0.1.19
- hubot-hipchat is pending till the similar https://github.com/StackStorm/hubot-hipchat/commit/c36a50d067b33e5e0e10c12190a63039815066ec ends up published
- hubot-irc is pending until https://github.com/nandub/hubot-irc#51d1f4b418fc039a456b7891c7f9bf836699cfdc (or the latest master) gets published

I've subscribed for updates on all three of them and will update dependencies as soon as new versions get published. For now, we'll have to use git references.
