### PR TITLE
Pin hubot-yammer version to git master

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,9 @@ as needed.
   * Replace `<VER>` with a version tag
 * Step 2: Push the container up: `docker push stackstorm/hubot:<VER>`
   * Use the same tag specified in Step 1.
-* Step 3: Profit
+* Step 3: Update the `latest` tag:
+  ```
+  docker build -t stackstorm/hubot:latest .
+  docker push stackstorm/hubot:latest
+  ```
+* Step 4: Profit

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "hubot-help"        : "^0.1.2",
     "hubot-stackstorm"  : "^0.3.1-rc2",
     "hubot-flowdock"    : "^0.7.6",
-    "hubot-yammer"      : "^0.2.0",
+    "hubot-yammer"      : "git+https://github.com/athieriot/hubot-yammer",
     "hubot-xmpp"        : "git+https://github.com/markstory/hubot-xmpp.git#94c3438e42778c53e38f6909939c514da50a0dca",
     "hubot-hipchat"     : "git+https://github.com/StackStorm/hubot-hipchat#sonnyp-patch",
     "hubot-irc"         : "git+https://github.com/nandub/hubot-irc#51d1f4b418fc039a456b7891c7f9bf836699cfdc",


### PR DESCRIPTION
Pinning `hubot-yammer` version to `master` branch of https://github.com/athieriot/hubot-yammer: since we can’t publish new versions to `npm` and I wouldn’t want to bug @athieriot with this too much, it would be better if we fetch the yammer adapter directly from git.

We do it with some other adapters, too; nothing new here.
