### PR TITLE
Comment out slack

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -35,13 +35,55 @@ export ST2_WEBUI_URL=https://${ST2_HOSTNAME}
 ######################################################################
 # Chat service adapter settings
 
-# For Slack, see https://github.com/slackhq/hubot-slack
-# For other adapters, see correspondent settings https://hubot.github.com/docs/adapters/
+# Uncomment one of the adapter blocks below.
+# Currently supported: slack, hipchat, xmpp, yammer, irc, flowdock.
 
-# Hubot adapter plugin: slack, hipchat, irc, yammer, xmpp, flowdock
-
-# Slack
+# Slack settings (https://github.com/slackhq/hubot-slack):
+#
 # export HUBOT_ADAPTER=slack
-
-# Slack authentication token
 # export HUBOT_SLACK_TOKEN=xoxb-CHANGE-ME-PLEASE
+
+# HipChat settings (https://github.com/hipchat/hubot-hipchat):
+#
+# export HUBOT_ADAPTER=hipchat
+# export HUBOT_HIPCHAT_JID=CHANGE-ME-PLEASE
+# export HUBOT_HIPCHAT_PASSWORD=CHANGE-ME-PLEASE
+#
+# Uncomment for HipChat Server:
+# export HUBOT_HIPCHAT_XMPP_DOMAIN=btf.hipchat.com
+
+# XMPP settings (https://github.com/markstory/hubot-xmpp):
+#
+# export HUBOT_ADAPTER=xmpp
+# export HUBOT_XMPP_USERNAME=CHANGE-ME-PLEASE
+# export HUBOT_XMPP_PASSWORD=CHANGE-ME-PLEASE
+# export HUBOT_XMPP_ROOMS=CHANGE-ME-PLEASE
+# export HUBOT_XMPP_HOST=CHANGE-ME-PLEASE
+# export HUBOT_XMPP_PORT=CHANGE-ME-PLEASE
+
+# FlowDock settings (https://github.com/flowdock/hubot-flowdock):
+#
+# export HUBOT_ADAPTER=flowdock
+# export HUBOT_FLOWDOCK_API_TOKEN=CHANGE-ME-PLEASE
+# export HUBOT_FLOWDOCK_LOGIN_EMAIL=CHANGE-ME-PLEASE
+# export HUBOT_FLOWDOCK_LOGIN_PASSWORD=CHANGE-ME-PLEASE
+
+# Yammer settings (https://github.com/athieriot/hubot-yammer):
+#
+# export HUBOT_ADAPTER=yammer
+# export HUBOT_YAMMER_ACCESS_TOKEN=CHANGE-ME-PLEASE
+# export HUBOT_YAMMER_GROUPS=CHANGE-ME-PLEASE
+
+# IRC settings (https://github.com/nandub/hubot-irc):
+#
+# export HUBOT_ADAPTER=irc
+# export HUBOT_IRC_SERVER=CHANGE-ME-PLEASE
+# export HUBOT_IRC_PORT=CHANGE-ME-PLEASE
+# export HUBOT_IRC_NICK=CHANGE-ME-PLEASE
+# export HUBOT_IRC_PASSWORD=CHANGE-ME-PLEASE
+# export HUBOT_IRC_ROOMS=CHANGE-ME-PLEASE
+# export HUBOT_IRC_NICKSERV_USERNAME=CHANGE-ME-PLEASE
+# export HUBOT_IRC_NICKSERV_PASSWORD=CHANGE-ME-PLEASE
+# export HUBOT_IRC_SERVER_FAKE_SSL=CHANGE-ME-PLEASE
+# export HUBOT_IRC_USESSL=CHANGE-ME-PLEASE
+# export HUBOT_IRC_UNFLOOD=CHANGE-ME-PLEASE

--- a/st2chatops.env
+++ b/st2chatops.env
@@ -41,7 +41,7 @@ export ST2_WEBUI_URL=https://${ST2_HOSTNAME}
 # Hubot adapter plugin: slack, hipchat, irc, yammer, xmpp, flowdock
 
 # Slack
-export HUBOT_ADAPTER=slack
+# export HUBOT_ADAPTER=slack
 
 # Slack authentication token
-export HUBOT_SLACK_TOKEN=xoxb-CHANGE-ME-PLEASE
+# export HUBOT_SLACK_TOKEN=xoxb-CHANGE-ME-PLEASE

--- a/testingenv/centos6/docker-entrypoint.sh
+++ b/testingenv/centos6/docker-entrypoint.sh
@@ -8,7 +8,8 @@ pull)
 test)
   rpm -i $ARTIFACT_DIR/*.rpm
   cd /opt/stackstorm/chatops
-  sed -i.bak -r "s/^(export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_USERNAME.).*/\1$ST2_USERNAME/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$ST2_PASSWORD/" st2chatops.env
   bin/hubot &> /tmp/hubot.log &

--- a/testingenv/centos7/docker-entrypoint.sh
+++ b/testingenv/centos7/docker-entrypoint.sh
@@ -8,7 +8,8 @@ pull)
 test)
   rpm -i $ARTIFACT_DIR/*.rpm
   cd /opt/stackstorm/chatops
-  sed -i.bak -r "s/^(export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_USERNAME.).*/\1$ST2_USERNAME/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$ST2_PASSWORD/" st2chatops.env
   bin/hubot &> /tmp/hubot.log &

--- a/testingenv/jessie/docker-entrypoint.sh
+++ b/testingenv/jessie/docker-entrypoint.sh
@@ -8,7 +8,8 @@ pull)
 test)
   dpkg -i $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
-  sed -i.bak -r "s/^(export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_USERNAME.).*/\1$ST2_USERNAME/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$ST2_PASSWORD/" st2chatops.env
   bin/hubot &> /tmp/hubot.log &

--- a/testingenv/trusty/docker-entrypoint.sh
+++ b/testingenv/trusty/docker-entrypoint.sh
@@ -8,7 +8,8 @@ pull)
 test)
   dpkg -i $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
-  sed -i.bak -r "s/^(export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_USERNAME.).*/\1$ST2_USERNAME/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$ST2_PASSWORD/" st2chatops.env
   bin/hubot &> /tmp/hubot.log &

--- a/testingenv/wheezy/docker-entrypoint.sh
+++ b/testingenv/wheezy/docker-entrypoint.sh
@@ -8,7 +8,8 @@ pull)
 test)
   dpkg -i $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
-  sed -i.bak -r "s/^(export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_USERNAME.).*/\1$ST2_USERNAME/" st2chatops.env
   sed -i.bak -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$ST2_PASSWORD/" st2chatops.env
   bin/hubot &> /tmp/hubot.log &


### PR DESCRIPTION
Comment out slack adapter as there's no good defaults. Service will continue to work.

This will need a correspondent change in https://github.com/StackStorm/st2-packages/pull/206/files cc @lakshmi-kannan to uncomment the lines.

Longer term, I'd like to ask @emedvedev to add all supported Chat Adapter's environment variables, commented out, so that user (or script) can uncomment them for a given provider.
