### PR TITLE
Version bump for hubot-stackstorm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st2-hubot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "st2_version": "1.4dev",
   "private": true,
   "author": "StackStorm <support@stackstorm.com>",
@@ -11,7 +11,7 @@
     "hubot-redis-brain" : "0.0.3",
     "hubot-scripts"     : "^2.16.2",
     "hubot-help"        : "^0.1.2",
-    "hubot-stackstorm"  : "^0.3.1-rc2",
+    "hubot-stackstorm"  : "^0.3.6",
     "hubot-flowdock"    : "^0.7.6",
     "hubot-yammer"      : "git+https://github.com/athieriot/hubot-yammer",
     "hubot-xmpp"        : "git+https://github.com/markstory/hubot-xmpp.git#94c3438e42778c53e38f6909939c514da50a0dca",


### PR DESCRIPTION
Bumping the `hubot-stackstorm` version and rebuilding the container to get the latest bugfix out. It’s not critical, but still annoying.

Bumping the container version, too, so that AIO people could do a smooth update.
