### PR TITLE
Change chatops.env defaults

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -25,9 +25,9 @@ export ST2_API="${ST2_API:-https://${ST2_HOSTNAME}/api}"
 # StackStorm auth endpoint. (Don’t use `localhost` as it would point to the Docker container).
 export ST2_AUTH_URL="${ST2_AUTH_URL:-https://${ST2_HOSTNAME}/auth}"
 
-# ST2 credentials. Uncomment and fill in to use any stackstorm account.
-# export ST2_AUTH_USERNAME=st2admin
-# export ST2_AUTH_PASSWORD=testp
+# ST2 credentials. Fill in to use any stackstorm account.
+export ST2_AUTH_USERNAME="${ST2_AUTH_USERNAME:-st2admin}"
+export ST2_AUTH_PASSWORD="${ST2_AUTH_PASSWORD:-testp}"
 
 # Public URL of StackStorm instance: used it to offer links to execution details in a chat.
 export ST2_WEBUI_URL=https://${ST2_HOSTNAME}

--- a/st2chatops.env
+++ b/st2chatops.env
@@ -13,21 +13,21 @@ export EXPRESS_PORT=8081
 export HUBOT_LOG_LEVEL=debug
 
 # Bot name
-export HUBOT_NAME=yourbot
-export HUBOT_ALIAS=?
+export HUBOT_NAME=hubot
+export HUBOT_ALIAS='!'
 
 ######################################################################
 # StackStorm settings
 
 # StackStorm api endpoint. (Don’t use `localhost` as it would point to the Docker container).
-export ST2_API=https://${ST2_HOSTNAME}/api
+export ST2_API="${ST2_API:-https://${ST2_HOSTNAME}/api}"
 
 # StackStorm auth endpoint. (Don’t use `localhost` as it would point to the Docker container).
-export ST2_AUTH_URL=https://${ST2_HOSTNAME}/auth
+export ST2_AUTH_URL="${ST2_AUTH_URL:-https://${ST2_HOSTNAME}/auth}"
 
-# ST2 credentials
-export ST2_AUTH_USERNAME=st2admin
-export ST2_AUTH_PASSWORD=testp
+# ST2 credentials. Uncomment and fill in to use any stackstorm account.
+# export ST2_AUTH_USERNAME=st2admin
+# export ST2_AUTH_PASSWORD=testp
 
 # Public URL of StackStorm instance: used it to offer links to execution details in a chat.
 export ST2_WEBUI_URL=https://${ST2_HOSTNAME}


### PR DESCRIPTION
Change chatops.env defaults to retain compatibility with AIO and also
use more conventional hubot name/alias.
