### PR TITLE
Fix the variable for Hubot's Slack token

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -65,7 +65,7 @@ test:
        -e ST2_HOSTNAME=${ST2_HOSTNAME} \
        -e ST2_USERNAME=${ST2_USERNAME} \
        -e ST2_PASSWORD=${ST2_PASSWORD} \
-       -e SLACK_TOKEN=${SLACK_TOKEN} \
+       -e HUBOT_SLACK_TOKEN=${SLACK_TOKEN} \
        ${DISTRO}-test test
      : parallel: true
   post:


### PR DESCRIPTION
CI has the wrong Slack token env variable, so it can’t finish the build (after https://github.com/enykeev/st2box/pull/4). 

Fixing the token variable name.
