### PR TITLE
Add example HUBOT_SLACK_EXIT_ON_DISCONNECT comment

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -42,6 +42,8 @@ export ST2_WEBUI_URL=https://${ST2_HOSTNAME}
 #
 # export HUBOT_ADAPTER=slack
 # export HUBOT_SLACK_TOKEN=xoxb-CHANGE-ME-PLEASE
+# Uncomment the following line to force hubot to exit if disconnected from slack.
+# export HUBOT_SLACK_EXIT_ON_DISCONNECT=1
 
 # HipChat settings (https://github.com/hipchat/hubot-hipchat):
 #


### PR DESCRIPTION
This should cause the slack adapter to exit if it's disconnected from Slack (say if they have an outage.
