### PR TITLE
st2chatops process discovery bro-hack

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -38,4 +38,5 @@ if [ ! -n "$HUBOT_ALIAS" ]; then
     fail "Must provide HUBOT_ALIAS to start"
 fi
 
-exec $HERE/node_modules/.bin/hubot "@"
+# Keep st2chatops hack (ignored by hubot) for process discovery
+exec $HERE/node_modules/.bin/hubot "@" st2chatops

--- a/bin/hubot
+++ b/bin/hubot
@@ -39,4 +39,4 @@ if [ ! -n "$HUBOT_ALIAS" ]; then
 fi
 
 # Keep st2chatops hack (ignored by hubot) for process discovery
-exec $HERE/node_modules/.bin/hubot "@" st2chatops
+exec $HERE/node_modules/.bin/hubot "$@" st2chatops


### PR DESCRIPTION
> Adresses stackstorm/st2#2779

This fixes `st2ctl` status for `st2chatops`: 

``` shell
$ st2ctl status

##### st2 components status #####
st2actionrunner PID: 1862
st2api PID: 1870
st2api PID: 2050
st2stream PID: 1877
st2stream PID: 2055
st2auth PID: 1884
st2auth PID: 2056
st2garbagecollector PID: 1891
st2notifier PID: 1898
st2resultstracker PID: 1905
st2rulesengine PID: 1912
st2sensorcontainer PID: 1920
st2chatops PID: 1929            #<----------
mistral-server is not running.
mistral-api is not running.
```

![screenshot from 2016-06-29 17-42-52](https://cloud.githubusercontent.com/assets/1533818/16456590/188bf1fa-3e21-11e6-8c59-adb5a9a992f3.png)
So far there are [no positional parameters](https://github.com/github/hubot/blob/master/bin/hubot#L11-L21) in hubot, so it's relatively safe time-bomb :smile: 

But I like this more, comparing to another hack https://github.com/StackStorm/st2/pull/2780, because it uses `st2chatops` explicitly, so it's more obvious to discover and shows `st2chatops` instead of `hubot` for `st2ctl status`.

---

As a bonus, caught the bug when additional arguments were not passed to `hubot` at all.
`"@"` -> `"$@"`
