### PR TITLE
Add `external-scripts.json` as a conffile on Debian (fixes: #53).

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,1 +1,2 @@
 /opt/stackstorm/chatops/st2chatops.env
+/opt/stackstorm/chatops/external-scripts.json

--- a/rpm/st2chatops.spec
+++ b/rpm/st2chatops.spec
@@ -53,3 +53,6 @@ Prefix:         /opt/stackstorm/chatops
 %else
   %{_sysconfdir}/rc.d/init.d/st2chatops
 %endif
+
+%config(noreplace) /opt/stackstorm/chatops/st2chatops.env
+%config(noreplace) /opt/stackstorm/chatops/external-scripts.json


### PR DESCRIPTION
A PR to address loss of locally configured hubot modules on Ubuntu (and Debian). 

This fixes issue #53.
