### PR TITLE
Fix Docker apt lock (master)

### DIFF
--- a/packagingenv/jessie/Dockerfile
+++ b/packagingenv/jessie/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # Install prerequesties
-RUN DEBIAN_FRONTEND=noninteractive apt-get clean && apt-get update && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -y install curl
 
 # Add NodeSource repo

--- a/packagingenv/wheezy/Dockerfile
+++ b/packagingenv/wheezy/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:wheezy
 
 # Install prerequesties
-RUN DEBIAN_FRONTEND=noninteractive apt-get clean && apt-get update && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -y install curl
 
 # Add NodeSource repo

--- a/testingenv/jessie/Dockerfile
+++ b/testingenv/jessie/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # Install prerequesties
-RUN DEBIAN_FRONTEND=noninteractive apt-get clean && apt-get update && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -y install curl
 
 # Add NodeSource repo

--- a/testingenv/wheezy/Dockerfile
+++ b/testingenv/wheezy/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:wheezy
 
 # Install prerequesties
-RUN DEBIAN_FRONTEND=noninteractive apt-get clean && apt-get update && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get -y install curl
 
 # Add NodeSource repo


### PR DESCRIPTION
Fixing the build failure https://circleci.com/gh/StackStorm/st2chatops/327#queue-placeholder/containers/1
```
Status: Downloaded newer image for debian:jessie

 ---> 040167067a69
Step 2 : RUN DEBIAN_FRONTEND=noninteractive apt-get clean && apt-get update &&     apt-get -y install curl
 ---> Running in 5f391f6d8b2d
E: Could not open lock file /var/cache/apt/archives/lock - open (2: No such file or directory)
E: Unable to lock the download directory
ERROR: Service 'jessie' failed to build: The command '/bin/sh -c DEBIAN_FRONTEND=noninteractive apt-get clean && apt-get update &&     apt-get -y install curl' returned a non-zero code: 100
```

Probably caused by Docker changes in upstream images.