### PR TITLE
Fix CI build failure by pinning docker-compose version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,7 +47,7 @@ dependencies:
   pre:
     - sudo apt-get update && sudo apt-get install -y rpm parallel jq
     - gem install package_cloud
-    - sudo pip install docker-compose
+    - sudo pip install "docker-compose==1.14.0"
     - docker-compose run ${DISTRO} pull
     - docker-compose run ${DISTRO}-test pull
   override:


### PR DESCRIPTION
Similar to: https://github.com/StackStorm/st2-packages/pull/475

This fixes an error: 
```
docker-compose run ${DISTRO} pull

ERROR: Cannot extend service 'suite' in /home/ubuntu/st2chatops/docker-compose.override.yml: Service not found

docker-compose run ${DISTRO} pull returned exit code 1

Action failed: docker-compose run ${DISTRO} pul
```