### PR TITLE
Fix ENV vars export consistency in service configs

### DIFF
--- a/debian/st2chatops.upstart
+++ b/debian/st2chatops.upstart
@@ -21,7 +21,9 @@ script
   DAEMON_ARGS=""
 
   # Read configuration variable file if it is present
+  set -o allexport
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+  set +o allexport
 
   exec bin/hubot $DAEMON_ARGS >> /var/log/st2/st2chatops.log 2>&1
 end script

--- a/rpm/st2chatops.init
+++ b/rpm/st2chatops.init
@@ -36,7 +36,9 @@ lockfile=/var/lock/subsys/$NAME
 [ -x "$DAEMON" ] || exit 5
 
 # Read configuration variable file if it is present
+set -o allexport
 [ -r /etc/sysconfig/$NAME ] && . /etc/sysconfig/$NAME
+set +o allexport
 DAEMON_ARGS=""
 
 


### PR DESCRIPTION
See https://github.com/StackStorm/st2-packages/pull/511 for problem description.

In short, for Ubuntu16, CentOS7 we place:
```
http_proxy=http://host/
```
in service config files (`/etc/default/`, `/etc/sysconfig/`)

While for `EL6` and `Ubuntu14` explicit `export` is needed:
```
export http_proxy=http://host/
```

This PR is going to fix the ENV behavior in service configs so it'll be consistent across the different platforms and packages we build.
No explicit `export` will be needed from now and all service configs remain in the same format.