### PR TITLE
Logrotate st2chatops logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ install: changelog
 	cp -R $(CURDIR)/node_modules $(DESTDIR)$(PREFIX)
 	cp -R $(CURDIR)/external-scripts.json $(DESTDIR)$(PREFIX)
 	cp -R $(CURDIR)/st2chatops.env $(DESTDIR)$(PREFIX)
+	install -m644 $(CURDIR)/conf/logrotate.conf $(DESTDIR)/etc/logrotate.d/st2chatops
 
 changelog:
 ifeq ($(DEBIAN),1)

--- a/conf/logrotate.conf
+++ b/conf/logrotate.conf
@@ -1,0 +1,11 @@
+## st2chatops hubot
+/var/log/st2/st2chatops.log {
+  size 10M
+  rotate 5
+  compress
+  notifempty
+  missingok
+  # st2chatops doesn't handle USR1 signal to re-open log files
+  copytruncate
+  delaycompress
+}

--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,2 +1,3 @@
 /opt/stackstorm/chatops/st2chatops.env
 /opt/stackstorm/chatops/external-scripts.json
+/etc/logrotate.d/st2chatops

--- a/debian/st2chatops.dirs
+++ b/debian/st2chatops.dirs
@@ -1,0 +1,3 @@
+/opt/stackstorm/chatops
+/var/log/st2
+/etc/logrotate.d

--- a/debian/st2chatops.dirs
+++ b/debian/st2chatops.dirs
@@ -1,3 +1,4 @@
+# Note: placing a path here will create directories for both deb/rpm to avoid code duplication
 /opt/stackstorm/chatops
 /var/log/st2
 /etc/logrotate.d

--- a/rpm/st2chatops.spec
+++ b/rpm/st2chatops.spec
@@ -49,6 +49,8 @@ Prefix:         /opt/stackstorm/chatops
 
 %files
   /opt/stackstorm/chatops/*
+  %attr(755, st2, root) %{_localstatedir}/log/st2
+  %config(noreplace) %{_sysconfdir}/logrotate.d/st2chatops
 %if 0%{?use_systemd}
   %{_unitdir}/st2chatops.service
 %else

--- a/rpm/st2chatops.spec
+++ b/rpm/st2chatops.spec
@@ -20,6 +20,13 @@ Prefix:         /opt/stackstorm/chatops
 %define _rpmdir %(pwd)/..
 %define _build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm
 
+# Cat debian/package.dirs, set buildroot prefix and create directories.
+%define debian_dirs cat debian/%{name}.dirs | grep -v '^\\s*#' | sed 's~^~%{buildroot}/~' | \
+          while read dir_path; do \
+            mkdir -p "${dir_path}" \
+          done \
+%{nil}
+
 %if 0%{?_unitdir:1}
   %define use_systemd 1
 %endif
@@ -37,12 +44,7 @@ Prefix:         /opt/stackstorm/chatops
   make
 
 %install
-  # Cat debian/package.dirs, set buildroot prefix and create directories.
-  %define debian_dirs cat debian/%{name}.dirs | grep -v '^\\s*#' | sed 's~^~%{buildroot}/~' | \
-            while read dir_path; do \
-              mkdir -p "${dir_path}" \
-            done \
-  %{nil}
+  %debian_dirs
   %make_install
 %if 0%{?use_systemd}
   install -D -p -m0644 %{_builddir}/rpm/st2chatops.service %{buildroot}%{_unitdir}/st2chatops.service

--- a/rpm/st2chatops.spec
+++ b/rpm/st2chatops.spec
@@ -37,6 +37,12 @@ Prefix:         /opt/stackstorm/chatops
   make
 
 %install
+  # Cat debian/package.dirs, set buildroot prefix and create directories.
+  %define debian_dirs cat debian/%{name}.dirs | grep -v '^\\s*#' | sed 's~^~%{buildroot}/~' | \
+            while read dir_path; do \
+              mkdir -p "${dir_path}" \
+            done \
+  %{nil}
   %make_install
 %if 0%{?use_systemd}
   install -D -p -m0644 %{_builddir}/rpm/st2chatops.service %{buildroot}%{_unitdir}/st2chatops.service


### PR DESCRIPTION
Fixes #76
Related to https://github.com/StackStorm/st2-packages/pull/514

Add logrotate configs for `st2chatops` deb/rpm packages to prevent filling up the disk space by logs.

