### PR TITLE
Add ST2_STREAM_URL option

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -25,6 +25,9 @@ export ST2_API="${ST2_API:-https://${ST2_HOSTNAME}/api}"
 # StackStorm auth endpoint.
 export ST2_AUTH_URL="${ST2_AUTH_URL:-https://${ST2_HOSTNAME}/auth}"
 
+# StackStorm stream endpoint.
+export ST2_STREAM_URL="${ST2_STREAM_URL:-https://${ST2_HOSTNAME}/stream}"
+
 # StackStorm API key
 export ST2_API_KEY="${ST2_API_KEY}"
 


### PR DESCRIPTION
Add `ST2_STREAM_URL` option to `st2chatops.env` which will be introduced in https://github.com/StackStorm/hubot-stackstorm/pull/144

This PR will remain WIP until following tasks are completed:
- [x] Update hubot-stackstorm version in `package.json` and `npm-shrinkwrap.json` after above PR is merged and a new version of hubot-stackstorm is released