### PR TITLE
v2.5.1: Pin ruby version to 2.0.0 for package_cloud

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,8 @@ machine:
       sudo chmod 0755 /usr/bin/docker
   services:
     - docker
+  ruby:
+    version: ruby-2.0.0-p645
   environment:
     DISTROS: "trusty xenial el6 el7"
     ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages


### PR DESCRIPTION
https://github.com/StackStorm/st2flow/pull/131