### PR TITLE
Added ability to override ST2_WEBUI_URL from global environment vars

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -33,7 +33,7 @@ export ST2_AUTH_USERNAME="${ST2_AUTH_USERNAME:-st2admin}"
 export ST2_AUTH_PASSWORD="${ST2_AUTH_PASSWORD:-testp}"
 
 # Public URL of StackStorm instance: used it to offer links to execution details in a chat.
-export ST2_WEBUI_URL=https://${ST2_HOSTNAME}
+export ST2_WEBUI_URL="${ST2_WEBUI_URL:-https://${ST2_HOSTNAME}}"
 
 ######################################################################
 # Chat service adapter settings


### PR DESCRIPTION
As described in #50 , global environment variables are supported to override values in `st2chatops.env`.

Previously the `ST2_WEBUI_URL` was not able to be overridden. This change allows the variable to be overridden by the global variables. 

Change is reflected in StackStorm/puppet-st2#199