### PR TITLE
Give a little bit more direction to Slack users

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -49,6 +49,8 @@ export ST2_WEBUI_URL="${ST2_WEBUI_URL:-https://${ST2_HOSTNAME}}"
 # Slack settings (https://github.com/slackhq/hubot-slack):
 #
 # export HUBOT_ADAPTER=slack
+# Obtain the Slack token from your app page at api.slack.com, it's the "Bot
+# User OAuth Access Token" in the "OAuth & Permissions" section.
 # export HUBOT_SLACK_TOKEN=xoxb-CHANGE-ME-PLEASE
 # Uncomment the following line to force hubot to exit if disconnected from slack.
 # export HUBOT_SLACK_EXIT_ON_DISCONNECT=1


### PR DESCRIPTION
Slack users are presented with two different access tokens: an "OAuth Access Token" and a "Bot User OAuth Access Token". They should use the second one, but there's not really anything [1] that explicitly indicates which token should be used for what.

This tiny PR explicitly calls out (a) where to obtain the access token and (b) which one of the two access tokens to use.

Considerations: if Slack ever rearranges their admin page this will be out of date, but in that case, the fact that the config file mentions the bot token should still help people pick the correct token if they manage to find the correct admin page for authorization/permissions.

[1] Besides the name "**Bot User** OAuth Access Token", which can _still_ be ambiguous for newbies who don't have any a priori knowledge of Slack or Hubot, and the barely-noticeable prefix on either token: `xoxp-` (ex oh ex **pee**) versus `xoxb-` (ex oh ex **bee**). I don't think either indication is explicit enough for complete idiots like me.