### PR TITLE
Use 'ST2_API_URL' ENV instead of 'ST2_API' for consistency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "st2-hubot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2799,8 +2799,9 @@
       }
     },
     "hubot-stackstorm": {
-      "version": "0.9.0",
-      "resolved": "git+https://github.com/StackStorm/hubot-stackstorm.git#24944ce9353ad8880012e225c4b4e1cacf82dd4f",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/hubot-stackstorm/-/hubot-stackstorm-0.9.2.tgz",
+      "integrity": "sha512-0W3aVBU2QxGN1C6BvQhcSue9dpY151eJLb/6lAIzLGuj52MzyCGISJE59gnclmNvEzWg1BOyiMbAD2jhHu9FPA==",
       "requires": {
         "cli-table": "<=1.0.0",
         "coffee-register": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st2-hubot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "st2_version": "3.0dev",
   "private": true,
   "author": "StackStorm <support@stackstorm.com>",
@@ -11,7 +11,7 @@
     "hubot-redis-brain": "0.0.4",
     "hubot-scripts": "^2.17.2",
     "hubot-help": "^0.2.2",
-    "hubot-stackstorm": "0.9.0",
+    "hubot-stackstorm": "0.9.1",
     "hubot-flowdock": "^0.7.8",
     "hubot-matteruser": "^4.4.0",
     "hubot-spark": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hubot-redis-brain": "0.0.4",
     "hubot-scripts": "^2.17.2",
     "hubot-help": "^0.2.2",
-    "hubot-stackstorm": "0.9.1",
+    "hubot-stackstorm": "0.9.2",
     "hubot-flowdock": "^0.7.8",
     "hubot-matteruser": "^4.4.0",
     "hubot-spark": "^2.0.0",

--- a/st2chatops.env
+++ b/st2chatops.env
@@ -20,7 +20,7 @@ export HUBOT_ALIAS='!'
 # StackStorm settings
 
 # StackStorm API endpoint.
-export ST2_API="${ST2_API:-https://${ST2_HOSTNAME}/api}"
+export ST2_API_URL="${ST2_API_URL:-https://${ST2_HOSTNAME}/api}"
 
 # StackStorm auth endpoint.
 export ST2_AUTH_URL="${ST2_AUTH_URL:-https://${ST2_HOSTNAME}/auth}"


### PR DESCRIPTION
> This is spot during the K8s work https://github.com/StackStorm/st2-dockerfiles/pull/19

Complementing https://github.com/StackStorm/hubot-stackstorm/pull/163

For consistency with other ENV variables (see https://docs.stackstorm.com/reference/cli.html#configuration), rename `ST2_API` -> `ST2_API_URL`.

Per https://github.com/StackStorm/hubot-stackstorm/pull/163 we still support old `ST2_API` for backwards compatibility. If there is some old `ST2_API` env var defined, it will take precedence and hubot will show a deprecation warning in logs. It means if user keeps old `st2chatops.env`, - it still would work after deb/rpm package upgrade.
