### PR TITLE
Allow overriding default 'st2chatops.env' variables

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -4,17 +4,17 @@ export ST2_HOSTNAME="${ST2_HOSTNAME:-localhost}"
 # Hubot settings
 
 # set if you don’t have a valid SSL certificate.
-export NODE_TLS_REJECT_UNAUTHORIZED=0
+export NODE_TLS_REJECT_UNAUTHORIZED="${NODE_TLS_REJECT_UNAUTHORIZED:-0}"
 
 # Hubot port - must be accessible from StackStorm
-export EXPRESS_PORT=8081
+export EXPRESS_PORT="${EXPRESS_PORT:-8081}"
 
 # Log level
-export HUBOT_LOG_LEVEL=debug
+export HUBOT_LOG_LEVEL="${HUBOT_LOG_LEVEL:-debug}"
 
 # Bot name
-export HUBOT_NAME=hubot
-export HUBOT_ALIAS='!'
+export HUBOT_NAME="${HUBOT_NAME:-hubot}"
+export HUBOT_ALIAS="${HUBOT_ALIAS:-!}"
 
 ######################################################################
 # StackStorm settings


### PR DESCRIPTION
Closes #50 
Needed for https://github.com/StackStorm/stackstorm-ha/issues/17 and https://github.com/StackStorm/st2-dockerfiles/pull/19 `st2chatops` K8s integration.

This PR allows passing to `st2chatops.env` ENV variables, - they'll take precedence over defaults. This way it's another option to override st2chatops settings instead of editing `st2chatops.env` file directly.
Useful in init systems (`/etc/sysconfig/st2chatops`, `/etc/default/st2chatops`) and in Docker environment.