### PR TITLE
Support Mattermost v5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -45,10 +45,125 @@
         "xtend": "^4.0.1"
       },
       "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
         "qs": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
           "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -112,6 +227,11 @@
           "requires": {
             "precond": "0.2"
           }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -154,6 +274,13 @@
         "sdp-transform": "^2.3.0",
         "uuid": "^3.0.1",
         "webrtc-adapter": "^3.2.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "@ciscospark/plugin-wdm": {
@@ -184,6 +311,13 @@
         "envify": "^3.4.1",
         "lodash": "^4.17.4",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "@ciscospark/storage-adapter-local-storage": {
@@ -213,11 +347,12 @@
     },
     "@rocket.chat/sdk": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/@rocket.chat/sdk/-/sdk-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rocket.chat/sdk/-/sdk-0.1.0.tgz",
       "integrity": "sha1-uFcXq9gf1bSFcm62tgno8bUKuBg=",
       "requires": {
         "@types/lru-cache": "^4.1.0",
         "@types/node": "^9.4.6",
+        "asteroid": "github:rocketchat/asteroid#a76a53254e381f9487aa2a9be3d874c9a2df6552",
         "lru-cache": "^4.1.1"
       }
     },
@@ -240,22 +375,135 @@
         "ws": "^1.0.1"
       },
       "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
         "bluebird": {
           "version": "3.5.3",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
           "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
     "@types/lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-8mNEUG6diOrI6pMqOHrHPDBB1JsrpedeMK9AWGzVCQ7StRRribiT9BRvUmF8aUws9iBbVlgVekOT5Sgzc1MTKw=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-ve2IoUJClE+4S/sG2zoLGEHP6DCvqgyz7UkHZdiICdQaAYRaCXsRWfJlbL8B0KvUyo9lgzD+oR0YSy4YikFyFQ=="
     },
     "@types/node": {
-      "version": "9.6.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.36.tgz",
-      "integrity": "sha512-Fbw+AdRLL01vv7Rk7bYaNPecqmKoinJHGbpKnDpbUZmUj/0vj3nLqPQ4CNBzr3q2zso6Cq/4jHoCAdH78fvJrw=="
+      "version": "9.6.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.47.tgz",
+      "integrity": "sha512-56wEJWXZs+3XXoTe/OCpdZ6czrONhy+6hT0GdPOb7HvudLTMJ1T5tuZPs37K5cPR5t+J9+vLPFDQgUQ8NWJE1w=="
     },
     "abbrev": {
       "version": "1.0.9",
@@ -285,24 +533,14 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "amdefine": {
@@ -388,24 +626,43 @@
       "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
     },
     "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
     },
     "ast-types": {
       "version": "0.9.6",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
       "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
     },
+    "asteroid": {
+      "version": "github:rocketchat/asteroid#a76a53254e381f9487aa2a9be3d874c9a2df6552",
+      "from": "github:rocketchat/asteroid",
+      "requires": {
+        "ddp.js": "^0.5.0",
+        "faye-websocket": "^0.11.0",
+        "q": "^1.0.1"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        }
+      }
+    },
     "async": {
-      "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -413,18 +670,18 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
       "version": "0.7.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.7.0.tgz",
       "integrity": "sha1-SJwmkETVBm36LGTHScsTGxdvSno="
     },
     "babel-polyfill": {
@@ -469,17 +726,16 @@
       "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
       "version": "0.9.5",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "requires": {
         "readable-stream": "~1.0.26"
@@ -487,7 +743,7 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "body-parser": {
@@ -509,7 +765,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
             "depd": "~1.1.2",
@@ -526,11 +782,11 @@
       }
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -557,30 +813,14 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "optional": true
-    },
     "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
+      "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk="
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -588,13 +828,6 @@
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "charenc": {
@@ -631,30 +864,6 @@
       "resolved": "https://registry.npmjs.org/cline/-/cline-0.8.2.tgz",
       "integrity": "sha1-6RHnQaCtLiTSnm+rLPifoyLVnHY="
     },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "optional": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "optional": true
-        }
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "coffee-register": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/coffee-register/-/coffee-register-2.2.0.tgz",
@@ -690,9 +899,9 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -761,9 +970,9 @@
       "integrity": "sha1-E6FHGFGKX8fMYjs/D0r4ee7X8c8="
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -776,26 +985,16 @@
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        }
+        "boom": "2.x.x"
       }
     },
     "ctype": {
       "version": "0.5.3",
-      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
     },
     "cycle": {
@@ -809,7 +1008,19 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
+    },
+    "ddp.js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ddp.js/-/ddp.js-0.5.0.tgz",
+      "integrity": "sha1-+XfuQgeDhXEgO/eB2vtXHQrr1mo="
     },
     "debug": {
       "version": "2.6.9",
@@ -819,16 +1030,18 @@
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "optional": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "defined": {
       "version": "1.0.0",
@@ -860,22 +1073,27 @@
       }
     },
     "detectrtc": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/detectrtc/-/detectrtc-1.3.7.tgz",
-      "integrity": "sha512-eniu45rJNjF95QdU19wVjiwnQEZjY2fKLyeTNUVFfSiQplBIP0No8v75X25/wUnIfIQB/ymaVMAfrB3WIYta8Q=="
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/detectrtc/-/detectrtc-1.3.9.tgz",
+      "integrity": "sha512-uDmANQib8St/dRppyQGXHX36qG2wel5dKHslqz0qr2958rcpN6heOzofV2PoKi7ogtCXpQuz0JUzazWhnLBPcA=="
     },
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -897,14 +1115,37 @@
         "through": "~2.3.4"
       }
     },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -936,11 +1177,6 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-    },
-    "esprima-fb": {
-      "version": "15001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
     },
     "estraverse": {
       "version": "1.9.3",
@@ -1020,9 +1256,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
+      "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -1035,9 +1271,9 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1049,6 +1285,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -1059,12 +1303,12 @@
     },
     "file-type": {
       "version": "3.9.0",
-      "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -1095,178 +1339,6 @@
       "requires": {
         "buffer-indexof": "^1.0.0",
         "request": "~2.58.0"
-      },
-      "dependencies": {
-        "asn1": {
-          "version": "0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
-        },
-        "assert-plus": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
-        },
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        },
-        "aws-sign2": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "caseless": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
-          "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk="
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "extend": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
-          "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
-        },
-        "form-data": {
-          "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "requires": {
-            "async": "^2.0.1",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.11"
-          },
-          "dependencies": {
-            "mime-types": {
-              "version": "2.1.21",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-              "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-              "requires": {
-                "mime-db": "~1.37.0"
-              }
-            }
-          }
-        },
-        "har-validator": {
-          "version": "1.8.0",
-          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
-          "requires": {
-            "bluebird": "^2.9.30",
-            "chalk": "^1.0.0",
-            "commander": "^2.8.1",
-            "is-my-json-valid": "^2.12.0"
-          }
-        },
-        "hawk": {
-          "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "http-signature": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-          "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
-          "requires": {
-            "asn1": "0.1.11",
-            "assert-plus": "^0.1.5",
-            "ctype": "0.5.3"
-          }
-        },
-        "mime-db": {
-          "version": "1.37.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
-        },
-        "mime-types": {
-          "version": "2.0.14",
-          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-          "requires": {
-            "mime-db": "~1.12.0"
-          },
-          "dependencies": {
-            "mime-db": {
-              "version": "1.12.0",
-              "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-              "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
-            }
-          }
-        },
-        "qs": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-          "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw="
-        },
-        "request": {
-          "version": "2.58.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.58.0.tgz",
-          "integrity": "sha1-tfScC5Sqt/rTiGEqH7atA7bMFYA=",
-          "requires": {
-            "aws-sign2": "~0.5.0",
-            "bl": "~0.9.0",
-            "caseless": "~0.10.0",
-            "combined-stream": "~1.0.1",
-            "extend": "~2.0.1",
-            "forever-agent": "~0.6.0",
-            "form-data": "~1.0.0-rc1",
-            "har-validator": "^1.6.1",
-            "hawk": "~2.3.0",
-            "http-signature": "~0.11.0",
-            "isstream": "~0.1.1",
-            "json-stringify-safe": "~5.0.0",
-            "mime-types": "~2.0.1",
-            "node-uuid": "~1.4.0",
-            "oauth-sign": "~0.8.0",
-            "qs": "~3.1.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": ">=0.12.0",
-            "tunnel-agent": "~0.4.0"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
       }
     },
     "for-each": {
@@ -1283,13 +1355,23 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "async": "^2.0.1",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.11"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        }
       }
     },
     "forwarded": {
@@ -1309,6 +1391,11 @@
       "requires": {
         "minimatch": "^3.0.2"
       }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "generate-function": {
       "version": "2.3.1",
@@ -1332,6 +1419,13 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "glob": {
@@ -1361,23 +1455,20 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
       "requires": {
-        "async": "^1.4.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -1387,12 +1478,22 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+      "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "bluebird": "^2.9.30",
+        "chalk": "^1.0.0",
+        "commander": "^2.8.1",
+        "is-my-json-valid": "^2.12.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -1408,21 +1509,26 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+    },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "http-errors": {
       "version": "1.7.2",
@@ -1437,18 +1543,18 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.6.tgz",
-      "integrity": "sha1-GVJz9YcExFLWcQdr4gEyndNB3FU="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
+      "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w=="
     },
     "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+      "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "asn1": "0.1.11",
+        "assert-plus": "^0.1.5",
+        "ctype": "0.5.3"
       }
     },
     "https-proxy-agent": {
@@ -1489,13 +1595,6 @@
         "log": "1.4.0",
         "optparse": "1.0.4",
         "scoped-http-client": "0.11.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        }
       }
     },
     "hubot-diagnostics": {
@@ -1524,35 +1623,6 @@
         "node-xmpp-client": "^2.1.0",
         "rsvp": "~1.2.0",
         "underscore": "~1.4.4"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        },
-        "node-xmpp-client": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-2.1.0.tgz",
-          "integrity": "sha1-i6fOmNrMhYadTRRrqq2H5SM2Ilg=",
-          "requires": {
-            "browser-request": "^0.3.3",
-            "debug": "^2.2.0",
-            "faye-websocket": "^0.10.0",
-            "istanbul": "^0.4.0",
-            "minimist": "^1.2.0",
-            "node-xmpp-core": "^4.1.0",
-            "request": "^2.65.0"
-          }
-        },
-        "rsvp": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/rsvp/-/rsvp-1.2.0.tgz",
-          "integrity": "sha1-CXoAGzAmwXJo0Xnex0K5nKYfqFM="
-        }
       }
     },
     "hubot-irc": {
@@ -1565,11 +1635,11 @@
       }
     },
     "hubot-matteruser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-4.4.0.tgz",
-      "integrity": "sha512-+JUM6MZnn0HMNihZ9m5+qqo1EywkGk1XrXdIyQ/V2WbebX60hro3Ohjjw7VjnayGec4dmrRKmf3E/gDiG2X9vw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.2.0.tgz",
+      "integrity": "sha512-kvUtKkN7U4RIaqVSxHRBsQCfonv/0KVdaCrz+gkT1sHX7OPd+bR1mEhgYEF3g1Cyx4XIOm+ZLvooPprtbfgj4A==",
       "requires": {
-        "mattermost-client": "^4.4.0",
+        "mattermost-client": "^6.1.0",
         "parent-require": "^1.0.0",
         "q": "^1.4.1"
       }
@@ -1580,35 +1650,6 @@
       "integrity": "sha1-kYLFd1YAZbNKBaLqHdq6Ix0JMCM=",
       "requires": {
         "redis": "~2.6.x"
-      },
-      "dependencies": {
-        "redis": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
-          "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
-          "requires": {
-            "double-ended-queue": "^2.1.0-0",
-            "redis-commands": "^1.2.0",
-            "redis-parser": "^2.0.0"
-          },
-          "dependencies": {
-            "double-ended-queue": {
-              "version": "2.1.0-0",
-              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
-            },
-            "redis-commands": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-              "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
-            },
-            "redis-parser": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-              "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
-            }
-          }
-        }
       }
     },
     "hubot-rocketchat": {
@@ -1664,7 +1705,7 @@
       "dependencies": {
         "request": {
           "version": "2.9.3",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.9.3.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.9.3.tgz",
           "integrity": "sha1-rArCYWlWiDfSiGqSsiwL0eFeetc="
         }
       }
@@ -1688,6 +1729,16 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.3.2.tgz",
           "integrity": "sha512-YObiFDoukx7qPBi/K0kUKyntEZDfBQiqs/DbrR1xzASKOBjGT7auD85/DiPeRr9k++lRj7l3uA9TNMLfyfcD/Q=="
+        },
+        "rsvp": {
+          "version": "4.8.4",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+          "integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -1700,10 +1751,129 @@
         "uuid": "2.0.2"
       },
       "dependencies": {
-        "uuid": {
-          "version": "2.0.2",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-          "integrity": "sha1-SL1WmPBnfjx5AaHEbvFbFkN5RyY="
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "node-xmpp-client": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.0.0.tgz",
+          "integrity": "sha1-UsxdO/fR/IbSd2pYL3x7yugCYTo=",
+          "requires": {
+            "browser-request": "^0.3.3",
+            "debug": "^2.2.0",
+            "faye-websocket": "^0.10.0",
+            "istanbul": "^0.4.0",
+            "minimist": "^1.2.0",
+            "node-xmpp-core": "^4.1.0",
+            "request": "^2.65.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
         }
       }
     },
@@ -1738,6 +1908,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
@@ -1753,9 +1928,9 @@
       }
     },
     "irc-colors": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.4.3.tgz",
-      "integrity": "sha512-VeAnFC9fkb4nB/s6UtTNf3BH2wOk/sSBSzIzCpFwrgoFxVl6J5sov7FXXA0kmbk/mVAZQXfXAsQFjWnGPf4cRg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.5.0.tgz",
+      "integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -1766,6 +1941,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-function": {
       "version": "1.0.1",
@@ -1793,6 +1973,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1833,29 +2029,43 @@
         "supports-color": "^3.1.0",
         "which": "^1.1.1",
         "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         }
       }
     },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1863,9 +2073,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1886,6 +2096,13 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "jstransform": {
@@ -1900,6 +2117,11 @@
         "source-map": "^0.4.2"
       },
       "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+        },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -1914,20 +2136,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/key-tree-store/-/key-tree-store-1.3.0.tgz",
       "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "optional": true
     },
     "levn": {
       "version": "0.3.0",
@@ -2019,37 +2227,31 @@
     },
     "log": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/log/-/log-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
       "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-    },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
     },
     "ltx": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
-      "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.1.tgz",
+      "integrity": "sha512-l4H1FS9I6IVqwvIpUHsSgyxE6t2jP7qd/2MeVG1UhmVK6vlHsQpfm2KNUcbdImeE0ai04vl1qTCF4CPCJqhknQ==",
       "requires": {
         "inherits": "^2.0.1"
       }
     },
     "mattermost-client": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-4.4.0.tgz",
-      "integrity": "sha512-qQhS5GgDejEhYzhDcynkFnfxLy8Gu1ZjzClcQxYXxlMeL2yeaKTbchGKNo9F0c99/ObDlgMAGr55+yc4jTeSjw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.1.0.tgz",
+      "integrity": "sha512-VSCkq59fyXz3EMye4Lnd/f6GwL8/zZW2uM1nM2waXjMPQIJSwGD+kwiwnQBGJ1C/lzUMgGn2gahOghcTGy315Q==",
       "requires": {
-        "coffee-script": "^1.10.0",
         "https-proxy-agent": "^2.1.0",
         "log": "^1.4.0",
         "request": "^2.73.0",
@@ -2057,10 +2259,113 @@
         "ws": "^1.0.1"
       },
       "dependencies": {
-        "coffee-script": {
-          "version": "1.12.7",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-          "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -2076,7 +2381,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
@@ -2095,16 +2400,16 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "~1.38.0"
       }
     },
     "min-document": {
@@ -2125,12 +2430,12 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -2138,7 +2443,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -2160,15 +2465,20 @@
       }
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "optional": true
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "neo-async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
     },
     "node-icu-charset-detector": {
       "version": "0.2.0",
@@ -2185,9 +2495,9 @@
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "node-xmpp-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.0.0.tgz",
-      "integrity": "sha1-UsxdO/fR/IbSd2pYL3x7yugCYTo=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-2.1.0.tgz",
+      "integrity": "sha1-i6fOmNrMhYadTRRrqq2H5SM2Ilg=",
       "requires": {
         "browser-request": "^0.3.3",
         "debug": "^2.2.0",
@@ -2198,13 +2508,113 @@
         "request": "^2.65.0"
       },
       "dependencies": {
-        "faye-websocket": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
           }
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -2246,9 +2656,9 @@
       "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
     },
     "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
     },
     "object.assign": {
       "version": "1.1.1",
@@ -2256,6 +2666,13 @@
       "integrity": "sha1-8ilnQnP5T8sjDQLBlYqLlOye+Vw=",
       "requires": {
         "object-keys": "~1.0.1"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+        }
       }
     },
     "on-finished": {
@@ -2285,7 +2702,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
@@ -2332,12 +2749,12 @@
       "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
     },
     "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
       "requires": {
-        "for-each": "^0.3.2",
-        "trim": "0.0.1"
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
       }
     },
     "parseurl": {
@@ -2404,10 +2821,15 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+    },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -2420,9 +2842,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -2447,7 +2869,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
             "depd": "~1.1.2",
@@ -2465,7 +2887,7 @@
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -2499,48 +2921,80 @@
     },
     "reconnect-core": {
       "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-      "integrity": "sha1-udryrcRbGabMX9LwSPjZQGzs5Jg=",
+      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
       "requires": {
         "backoff": "~2.3.0"
       }
+    },
+    "redis": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
+      "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.4.0.tgz",
+      "integrity": "sha512-cu8EF+MtkwI4DLIT0x9P8qNTLFhQD4jLfxLR0cCNkeGzs87FN6879JOJwNQR/1zD7aSYNbU0hgsV9zGY71Itvw=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
     "request": {
-      "version": "2.85.0",
-      "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
+      "integrity": "sha1-tfScC5Sqt/rTiGEqH7atA7bMFYA=",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "~0.5.0",
+        "bl": "~0.9.0",
+        "caseless": "~0.10.0",
+        "combined-stream": "~1.0.1",
+        "extend": "~2.0.1",
+        "forever-agent": "~0.6.0",
+        "form-data": "~1.0.0-rc1",
+        "har-validator": "^1.6.1",
+        "hawk": "~2.3.0",
+        "http-signature": "~0.11.0",
+        "isstream": "~0.1.1",
+        "json-stringify-safe": "~5.0.0",
+        "mime-types": "~2.0.1",
+        "node-uuid": "~1.4.0",
+        "oauth-sign": "~0.8.0",
+        "qs": "~3.1.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": ">=0.12.0",
+        "tunnel-agent": "~0.4.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "requires": {
+            "mime-db": "~1.12.0"
+          }
+        },
+        "qs": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
+          "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw="
+        }
       }
     },
     "requires-port": {
@@ -2558,19 +3012,10 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
       "integrity": "sha1-b2l+UKDk3cjI9/tUeptg3q1DZ40="
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
     "rsvp": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
-      "integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-1.2.0.tgz",
+      "integrity": "sha1-CXoAGzAmwXJo0Xnex0K5nKYfqFM="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -2593,9 +3038,9 @@
       "integrity": "sha1-jgOPbdsUvXZa4fS1IW4SCUUR4NA="
     },
     "sdp-transform": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.5.0.tgz",
-      "integrity": "sha512-iktBwqgfhfsCu1szik/NRAUXmLbx7mFb3zRzQrrNJSdj9e6OvB0pAH6ZxdG8YwUCWwybZVhcI+45MN/FwVoAag=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.7.0.tgz",
+      "integrity": "sha512-v8/zfKeDKBEXKMf4UT91owHoXM6O+s8gEVtCVSvrAd2eEtuv5u4TKcTXX4a9qrQM3T2Ycr9rLyU+Ww3ZiCiaGQ=="
     },
     "send": {
       "version": "0.16.2",
@@ -2619,7 +3064,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
             "depd": "~1.1.2",
@@ -2657,11 +3102,11 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "2.x.x"
       }
     },
     "source-map": {
@@ -2679,9 +3124,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -2690,7 +3135,23 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "st2client": {
@@ -2718,31 +3179,38 @@
       "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
       "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      }
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "requires": {
-        "has-flag": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "text-encoding": {
       "version": "0.5.5",
@@ -2751,12 +3219,12 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.6.5",
-      "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
@@ -2774,17 +3242,14 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
       "requires": {
-        "punycode": "^1.4.1"
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "truncate": {
       "version": "2.0.1",
@@ -2792,18 +3257,14 @@
       "integrity": "sha1-3RptFWMFFWY9hHX28k7fL4AOuxs="
     },
     "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -2823,29 +3284,22 @@
       }
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.2.tgz",
+      "integrity": "sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==",
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "commander": "~2.19.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "optional": true
         }
       }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
     },
     "uid-safe": {
       "version": "2.1.5",
@@ -2869,6 +3323,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "url-join": {
       "version": "0.0.1",
@@ -2895,9 +3357,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+      "integrity": "sha1-SL1WmPBnfjx5AaHEbvFbFkN5RyY="
     },
     "vary": {
       "version": "1.1.2",
@@ -2912,6 +3374,13 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "webrtc-adapter": {
@@ -2932,23 +3401,17 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
-      "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0="
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "optional": true
     },
     "winston": {
       "version": "2.4.4",
@@ -2965,7 +3428,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }
@@ -2998,18 +3461,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "optional": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -218,19 +218,7 @@
       "requires": {
         "@types/lru-cache": "^4.1.0",
         "@types/node": "^9.4.6",
-        "asteroid": "github:rocketchat/asteroid#a76a53254e381f9487aa2a9be3d874c9a2df6552",
         "lru-cache": "^4.1.1"
-      },
-      "dependencies": {
-        "asteroid": {
-          "version": "github:rocketchat/asteroid#a76a53254e381f9487aa2a9be3d874c9a2df6552",
-          "from": "github:rocketchat/asteroid",
-          "requires": {
-            "ddp.js": "^0.5.0",
-            "faye-websocket": "^0.11.0",
-            "q": "^1.0.1"
-          }
-        }
       }
     },
     "@slack/client": {
@@ -529,6 +517,11 @@
             "setprototypeof": "1.1.0",
             "statuses": ">= 1.4.0 < 2"
           }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         }
       }
     },
@@ -686,10 +679,10 @@
         }
       }
     },
-    "coffee-script": {
+    "coffeescript": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
-      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4="
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.6.3.tgz",
+      "integrity": "sha1-QXSXUMYhplU8fAOBilOEuyTDBUE="
     },
     "colors": {
       "version": "1.0.3",
@@ -817,11 +810,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "ddp.js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ddp.js/-/ddp.js-0.5.0.tgz",
-      "integrity": "sha1-+XfuQgeDhXEgO/eB2vtXHQrr1mo="
     },
     "debug": {
       "version": "2.6.9",
@@ -1019,6 +1007,11 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -1055,14 +1048,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-    },
-    "faye-websocket": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-      "requires": {
-        "websocket-driver": ">=0.5.1"
-      }
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -1440,13 +1425,13 @@
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "http-errors": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
-      "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
+        "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
@@ -1491,14 +1476,14 @@
       }
     },
     "hubot": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/hubot/-/hubot-3.1.1.tgz",
-      "integrity": "sha512-r57C1CGZmUaADRom6CGi8aL0J3rPIV3fHYvVA+Zv7kPtsfZiwDcqF+x89QrKP5zidN9+0LVCbTnbzwXP8QDfUA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/hubot/-/hubot-3.3.1.tgz",
+      "integrity": "sha512-5+bFSAPrYjYm7bvPbrAsAxL30vbmAnriwUfyVy5B5SKubHOzfIj6d1IgHa7RrWxMyhvYkuRIqTo6XomMS/3uUQ==",
       "requires": {
         "async": ">=0.1.0 <1.0.0",
         "chalk": "^1.0.0",
         "cline": "^0.8.2",
-        "coffee-script": "1.6.3",
+        "coffeescript": "1.6.3",
         "connect-multiparty": "^2.1.1",
         "express": "^4.16.3",
         "log": "1.4.0",
@@ -1541,6 +1526,14 @@
         "underscore": "~1.4.4"
       },
       "dependencies": {
+        "faye-websocket": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        },
         "node-xmpp-client": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-2.1.0.tgz",
@@ -1553,1134 +1546,12 @@
             "minimist": "^1.2.0",
             "node-xmpp-core": "^4.1.0",
             "request": "^2.65.0"
-          },
-          "dependencies": {
-            "browser-request": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-              "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
-            },
-            "debug": {
-              "version": "2.6.8",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-              "requires": {
-                "ms": "2.0.0"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                }
-              }
-            },
-            "faye-websocket": {
-              "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-              "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-              "requires": {
-                "websocket-driver": ">=0.5.1"
-              },
-              "dependencies": {
-                "websocket-driver": {
-                  "version": "0.6.5",
-                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-                  "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-                  "requires": {
-                    "websocket-extensions": ">=0.1.1"
-                  },
-                  "dependencies": {
-                    "websocket-extensions": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-                      "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec="
-                    }
-                  }
-                }
-              }
-            },
-            "istanbul": {
-              "version": "0.4.5",
-              "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-              "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-              "requires": {
-                "abbrev": "1.0.x",
-                "async": "1.x",
-                "escodegen": "1.8.x",
-                "esprima": "2.7.x",
-                "glob": "^5.0.15",
-                "handlebars": "^4.0.1",
-                "js-yaml": "3.x",
-                "mkdirp": "0.5.x",
-                "nopt": "3.x",
-                "once": "1.x",
-                "resolve": "1.1.x",
-                "supports-color": "^3.1.0",
-                "which": "^1.1.1",
-                "wordwrap": "^1.0.0"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
-                },
-                "async": {
-                  "version": "1.5.2",
-                  "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-                },
-                "escodegen": {
-                  "version": "1.8.1",
-                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-                  "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-                  "requires": {
-                    "esprima": "^2.7.1",
-                    "estraverse": "^1.9.1",
-                    "esutils": "^2.0.2",
-                    "optionator": "^0.8.1",
-                    "source-map": "~0.2.0"
-                  },
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "1.9.3",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-                    },
-                    "optionator": {
-                      "version": "0.8.2",
-                      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-                      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-                      "requires": {
-                        "deep-is": "~0.1.3",
-                        "fast-levenshtein": "~2.0.4",
-                        "levn": "~0.3.0",
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2",
-                        "wordwrap": "~1.0.0"
-                      },
-                      "dependencies": {
-                        "deep-is": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-                        },
-                        "fast-levenshtein": {
-                          "version": "2.0.6",
-                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-                        },
-                        "levn": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-                          "requires": {
-                            "prelude-ls": "~1.1.2",
-                            "type-check": "~0.3.2"
-                          }
-                        },
-                        "prelude-ls": {
-                          "version": "1.1.2",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-                        },
-                        "type-check": {
-                          "version": "0.3.2",
-                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                          "requires": {
-                            "prelude-ls": "~1.1.2"
-                          }
-                        }
-                      }
-                    },
-                    "source-map": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-                      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-                      "optional": true,
-                      "requires": {
-                        "amdefine": ">=0.0.4"
-                      },
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                  "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-                },
-                "glob": {
-                  "version": "5.0.15",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                  "requires": {
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "2 || 3",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                      "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                      "requires": {
-                        "brace-expansion": "^1.1.7"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                          "requires": {
-                            "balanced-match": "^1.0.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-                    }
-                  }
-                },
-                "handlebars": {
-                  "version": "4.0.10",
-                  "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-                  "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-                  "requires": {
-                    "async": "^1.4.0",
-                    "optimist": "^0.6.1",
-                    "source-map": "^0.4.4",
-                    "uglify-js": "^2.6"
-                  },
-                  "dependencies": {
-                    "optimist": {
-                      "version": "0.6.1",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-                      "requires": {
-                        "minimist": "~0.0.1",
-                        "wordwrap": "~0.0.2"
-                      },
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.10",
-                          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-                        },
-                        "wordwrap": {
-                          "version": "0.0.3",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-                        }
-                      }
-                    },
-                    "source-map": {
-                      "version": "0.4.4",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                      "requires": {
-                        "amdefine": ">=0.0.4"
-                      },
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-                        }
-                      }
-                    },
-                    "uglify-js": {
-                      "version": "2.8.29",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                      "optional": true,
-                      "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
-                      },
-                      "dependencies": {
-                        "source-map": {
-                          "version": "0.5.6",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-                          "optional": true
-                        },
-                        "uglify-to-browserify": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-                          "optional": true
-                        },
-                        "yargs": {
-                          "version": "3.10.0",
-                          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                          "optional": true,
-                          "requires": {
-                            "camelcase": "^1.0.2",
-                            "cliui": "^2.1.0",
-                            "decamelize": "^1.0.0",
-                            "window-size": "0.1.0"
-                          },
-                          "dependencies": {
-                            "camelcase": {
-                              "version": "1.2.1",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                              "optional": true
-                            },
-                            "cliui": {
-                              "version": "2.1.0",
-                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                              "optional": true,
-                              "requires": {
-                                "center-align": "^0.1.1",
-                                "right-align": "^0.1.1",
-                                "wordwrap": "0.0.2"
-                              },
-                              "dependencies": {
-                                "center-align": {
-                                  "version": "0.1.3",
-                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                                  "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-                                  "optional": true,
-                                  "requires": {
-                                    "align-text": "^0.1.3",
-                                    "lazy-cache": "^1.0.3"
-                                  },
-                                  "dependencies": {
-                                    "align-text": {
-                                      "version": "0.1.4",
-                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                                      "optional": true,
-                                      "requires": {
-                                        "kind-of": "^3.0.2",
-                                        "longest": "^1.0.1",
-                                        "repeat-string": "^1.5.2"
-                                      },
-                                      "dependencies": {
-                                        "kind-of": {
-                                          "version": "3.2.2",
-                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                          "optional": true,
-                                          "requires": {
-                                            "is-buffer": "^1.1.5"
-                                          },
-                                          "dependencies": {
-                                            "is-buffer": {
-                                              "version": "1.1.5",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-                                              "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-                                              "optional": true
-                                            }
-                                          }
-                                        },
-                                        "longest": {
-                                          "version": "1.0.1",
-                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                          "optional": true
-                                        },
-                                        "repeat-string": {
-                                          "version": "1.6.1",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                                          "optional": true
-                                        }
-                                      }
-                                    },
-                                    "lazy-cache": {
-                                      "version": "1.0.4",
-                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                                      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "right-align": {
-                                  "version": "0.1.3",
-                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                                  "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-                                  "optional": true,
-                                  "requires": {
-                                    "align-text": "^0.1.1"
-                                  },
-                                  "dependencies": {
-                                    "align-text": {
-                                      "version": "0.1.4",
-                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                                      "optional": true,
-                                      "requires": {
-                                        "kind-of": "^3.0.2",
-                                        "longest": "^1.0.1",
-                                        "repeat-string": "^1.5.2"
-                                      },
-                                      "dependencies": {
-                                        "kind-of": {
-                                          "version": "3.2.2",
-                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                          "optional": true,
-                                          "requires": {
-                                            "is-buffer": "^1.1.5"
-                                          },
-                                          "dependencies": {
-                                            "is-buffer": {
-                                              "version": "1.1.5",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-                                              "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-                                              "optional": true
-                                            }
-                                          }
-                                        },
-                                        "longest": {
-                                          "version": "1.0.1",
-                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                          "optional": true
-                                        },
-                                        "repeat-string": {
-                                          "version": "1.6.1",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                                          "optional": true
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "wordwrap": {
-                                  "version": "0.0.2",
-                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                                  "optional": true
-                                }
-                              }
-                            },
-                            "decamelize": {
-                              "version": "1.2.0",
-                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-                              "optional": true
-                            },
-                            "window-size": {
-                              "version": "0.1.0",
-                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                              "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "js-yaml": {
-                  "version": "3.9.0",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-                  "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
-                  "requires": {
-                    "argparse": "^1.0.7",
-                    "esprima": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "argparse": {
-                      "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-                      "requires": {
-                        "sprintf-js": "~1.0.2"
-                      },
-                      "dependencies": {
-                        "sprintf-js": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-                      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                  "requires": {
-                    "minimist": "0.0.8"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.6",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-                  "requires": {
-                    "abbrev": "1"
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "requires": {
-                    "wrappy": "1"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                    }
-                  }
-                },
-                "resolve": {
-                  "version": "1.1.7",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                  "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-                },
-                "supports-color": {
-                  "version": "3.2.3",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                  "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                  "requires": {
-                    "has-flag": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-                    }
-                  }
-                },
-                "which": {
-                  "version": "1.2.14",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-                  "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-                  "requires": {
-                    "isexe": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "isexe": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-                      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-                    }
-                  }
-                },
-                "wordwrap": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                  "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "node-xmpp-core": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/node-xmpp-core/-/node-xmpp-core-4.2.0.tgz",
-              "integrity": "sha1-fi4EDB5apkvjUBO9w0Ey7Ddpla4=",
-              "requires": {
-                "debug": "^2.2.0",
-                "inherits": "^2.0.1",
-                "lodash.assign": "^3.2.0",
-                "ltx": "^2.0.1",
-                "node-xmpp-jid": "^2.0.0",
-                "reconnect-core": "https://github.com/dodo/reconnect-core/tarball/merged",
-                "tls-connect": "^0.2.2"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                },
-                "lodash.assign": {
-                  "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-                  "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-                  "requires": {
-                    "lodash._baseassign": "^3.0.0",
-                    "lodash._createassigner": "^3.0.0",
-                    "lodash.keys": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "lodash._baseassign": {
-                      "version": "3.2.0",
-                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-                      "requires": {
-                        "lodash._basecopy": "^3.0.0",
-                        "lodash.keys": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "lodash._basecopy": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-                        }
-                      }
-                    },
-                    "lodash._createassigner": {
-                      "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-                      "requires": {
-                        "lodash._bindcallback": "^3.0.0",
-                        "lodash._isiterateecall": "^3.0.0",
-                        "lodash.restparam": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "lodash._bindcallback": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-                          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-                        },
-                        "lodash._isiterateecall": {
-                          "version": "3.0.9",
-                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-                        },
-                        "lodash.restparam": {
-                          "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-                        }
-                      }
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.2",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-                      "requires": {
-                        "lodash._getnative": "^3.0.0",
-                        "lodash.isarguments": "^3.0.0",
-                        "lodash.isarray": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.1.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-                        },
-                        "lodash.isarray": {
-                          "version": "3.0.4",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-                        }
-                      }
-                    }
-                  }
-                },
-                "ltx": {
-                  "version": "2.7.1",
-                  "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
-                  "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
-                  "requires": {
-                    "inherits": "^2.0.1"
-                  }
-                },
-                "node-xmpp-jid": {
-                  "version": "2.3.0",
-                  "resolved": "https://registry.npmjs.org/node-xmpp-jid/-/node-xmpp-jid-2.3.0.tgz",
-                  "integrity": "sha1-YKPJUFgqDNz9oHRJQ1eoUXjziHg="
-                },
-                "reconnect-core": {
-                  "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-                  "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
-                  "requires": {
-                    "backoff": "~2.3.0"
-                  },
-                  "dependencies": {
-                    "backoff": {
-                      "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
-                      "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
-                    }
-                  }
-                },
-                "tls-connect": {
-                  "version": "0.2.2",
-                  "resolved": "https://registry.npmjs.org/tls-connect/-/tls-connect-0.2.2.tgz",
-                  "integrity": "sha1-HYjU9MuCmgdBtqzQXR33Pg1Wb9A="
-                }
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-                },
-                "aws4": {
-                  "version": "1.6.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-                },
-                "caseless": {
-                  "version": "0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                  "requires": {
-                    "delayed-stream": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-                },
-                "form-data": {
-                  "version": "2.1.4",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                  "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
-                  },
-                  "dependencies": {
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                  "requires": {
-                    "ajv": "^4.9.1",
-                    "har-schema": "^1.0.5"
-                  },
-                  "dependencies": {
-                    "ajv": {
-                      "version": "4.11.8",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                      "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "co": {
-                          "version": "4.6.0",
-                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-                        },
-                        "json-stable-stringify": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-                          "requires": {
-                            "jsonify": "~0.0.0"
-                          },
-                          "dependencies": {
-                            "jsonify": {
-                              "version": "0.0.0",
-                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "har-schema": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                  "requires": {
-                    "boom": "2.x.x",
-                    "cryptiles": "2.x.x",
-                    "hoek": "2.x.x",
-                    "sntp": "1.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                      "requires": {
-                        "boom": "2.x.x"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                  "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-                    },
-                    "jsprim": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                        },
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-                        },
-                        "json-schema": {
-                          "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.13.1",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-                      "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                          "optional": true,
-                          "requires": {
-                            "tweetnacl": "^0.14.3"
-                          }
-                        },
-                        "dashdash": {
-                          "version": "1.14.1",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.7",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.5",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-                },
-                "mime-types": {
-                  "version": "2.1.15",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-                  "requires": {
-                    "mime-db": "~1.27.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-                },
-                "performance-now": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-                },
-                "qs": {
-                  "version": "6.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                  "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-                  "requires": {
-                    "punycode": "^1.4.1"
-                  },
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-                    }
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                  "requires": {
-                    "safe-buffer": "^5.0.1"
-                  }
-                },
-                "uuid": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-                  "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-                }
-              }
-            }
           }
         },
         "rsvp": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/rsvp/-/rsvp-1.2.0.tgz",
           "integrity": "sha1-CXoAGzAmwXJo0Xnex0K5nKYfqFM="
-        },
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
         }
       }
     },
@@ -2765,9 +1636,9 @@
       }
     },
     "hubot-slack": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/hubot-slack/-/hubot-slack-4.5.5.tgz",
-      "integrity": "sha512-nlURcILQG1tdE3bA2BUiAvFpmMe/wwoaJVFT9Kzet2BC5pLZoZDdXZOLYAQBfUJUq/2mkLJfsuykvna3PezHUQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/hubot-slack/-/hubot-slack-4.6.0.tgz",
+      "integrity": "sha512-eYnOmn76kMOQzjPKKM6/woanhUG7EwhgviH34MNWkf2EhlkkouKSe0wTkIt4n9OPbvuDf+531PO+XeKXMs4nrA==",
       "requires": {
         "@slack/client": "3.16.1-sec.2",
         "bluebird": "^3.5.1",
@@ -3584,6 +2455,11 @@
             "setprototypeof": "1.1.0",
             "statuses": ">= 1.4.0 < 2"
           }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         }
       }
     },
@@ -3623,7 +2499,7 @@
     },
     "reconnect-core": {
       "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
+      "integrity": "sha1-udryrcRbGabMX9LwSPjZQGzs5Jg=",
       "requires": {
         "backoff": "~2.3.0"
       }
@@ -3752,6 +2628,11 @@
             "statuses": ">= 1.4.0 < 2"
           }
         },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -3771,9 +2652,9 @@
       }
     },
     "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sntp": {
       "version": "2.1.0",
@@ -3865,7 +2746,7 @@
     },
     "text-encoding": {
       "version": "0.5.5",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.5.5.tgz",
       "integrity": "sha1-0phF2cHyrFzrpL+GHFYYVsUjrFM="
     },
     "through": {
@@ -3978,6 +2859,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "hubot-help": "^0.2.2",
     "hubot-stackstorm": "0.9.2",
     "hubot-flowdock": "^0.7.8",
-    "hubot-matteruser": "^4.4.0",
+    "hubot-matteruser": "^5.2.0",
     "hubot-spark": "^2.0.0",
     "hubot-xmpp": "^0.2.5",
     "hubot-hipchat": "git+https://github.com/StackStorm/hubot-hipchat#sonnyp-patch",


### PR DESCRIPTION
Update hubot-matteruser dependency to `5.2.0` so we support Mattermost version 5 servers.

Special thanks to @killsudo from #community for testing this and creating [instructions for other users](https://stackstorm-community.slack.com/archives/C4F3BG01F/p1553715790131800).