### PR TITLE
Create a new environment variable `EXIT_ON_FAILURES`.

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -38,6 +38,9 @@ export ST2_AUTH_PASSWORD="${ST2_AUTH_PASSWORD:-testp}"
 # Public URL of StackStorm instance: used it to offer links to execution details in a chat.
 export ST2_WEBUI_URL="${ST2_WEBUI_URL:-https://${ST2_HOSTNAME}}"
 
+# Uncomment the following line to force st2chatops to exit from stackstrom failures.
+# export EXIT_ON_FAILURES=1
+
 ######################################################################
 # Chat service adapter settings
 


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2chatops/issues/124

`EXIT_ON_FAILURES` default value is `false` and is optional.

If `EXIT_ON_FAILURES` is setup, for the case if `st2chatops` encounters authenticate or unresolved application URL issues with Stackstorm,  instead it's being unresponsive/hanging/waiting in a running state, `st2chatops` will be exit.

