### PR TITLE
Add instruction for how to do password authentication. 

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -32,7 +32,8 @@ export ST2_STREAM_URL="${ST2_STREAM_URL:-https://${ST2_HOSTNAME}/stream}"
 export ST2_API_KEY="${ST2_API_KEY}"
 
 # ST2 credentials. Fill in to use any stackstorm account.
-# ST2 username:password pair will rely on authentication token re-generation.
+# ST2 username:password pair will result in authentication token re-generation.
+# (Uncomment ST2_AUTH_URL, ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD and comment out ST2_API_KEY)
 export ST2_AUTH_USERNAME="${ST2_AUTH_USERNAME:-st2admin}"
 export ST2_AUTH_PASSWORD="${ST2_AUTH_PASSWORD:-testp}"
 


### PR DESCRIPTION
Add note to  instruction for how to do password authentication`ST2_AUTH_URL`, `ST2_AUTH_USERNAME', and `ST2_AUTH_PASSWORD` all have to work together.

This commit did NOT automatically include into pull  https://github.com/StackStorm/st2chatops/pull/129. Have to create a new pull.  