### PR TITLE
WIP: EL8 rpm package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     machine: true
     working_directory: ~/StackStorm/st2chatops
-    parallelism: 5
+    parallelism: 6
     shell: /bin/bash --login
     environment:
       DISTROS: trusty xenial bionic el6 el7 el8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     parallelism: 5
     shell: /bin/bash --login
     environment:
-      DISTROS: trusty xenial bionic el6 el7
+      DISTROS: trusty xenial bionic el6 el7 el8
       ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
       ST2_TEST_ENVIRONMENT: https://github.com/StackStorm/st2-docker
       DEPLOY_PACKAGES: 1
@@ -107,7 +107,7 @@ jobs:
       - image: circleci/ruby:2.4
     working_directory: ~/packages
     environment:
-      DISTROS: "trusty xenial bionic el6 el7"
+      DISTROS: "trusty xenial bionic el6 el7 el8"
     steps:
       - attach_workspace:
           at: /home/circleci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ bionic:
     file: docker-compose.override.yml
     service: suite
 
+el8:
+  build: ./packagingenv/centos8
+  extends:
+    file: docker-compose.override.yml
+    service: suite
+
 el7:
   build: ./packagingenv/centos7
   extends:
@@ -44,6 +50,12 @@ xenial-test:
 
 bionic-test:
   build: ./testingenv/bionic
+  extends:
+    file: docker-compose.override.yml
+    service: suite-test
+
+el8-test:
+  build: ./testingenv/centos8
   extends:
     file: docker-compose.override.yml
     service: suite-test

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,158 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-      "requires": {
-        "@babel/highlight": "^7.0.0"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
-      "requires": {
-        "@babel/types": "^7.4.4",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "requires": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-      "requires": {
-        "@babel/types": "^7.4.4"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-      "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@babel/parser": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
-    },
-    "@babel/template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.5",
-        "@babel/types": "^7.4.4",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-      "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "@ciscospark/common": {
       "version": "0.7.87",
       "resolved": "https://registry.npmjs.org/@ciscospark/common/-/common-0.7.87.tgz",
@@ -264,6 +112,15 @@
           "requires": {
             "precond": "0.2"
           }
+        },
+        "ws": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
         }
       }
     },
@@ -354,30 +211,23 @@
       "integrity": "sha512-1lc1ptKNT+f6eS9FA7sJPAeqjM00xfwcEU6fBjVa6VLPI0pjGJHRoxBuA2ghQ16TyjilDnCxZb6dQl+WW54CKg==",
       "requires": {
         "source-map": "^0.5.6"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
       }
     },
     "@rocket.chat/sdk": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/@rocket.chat/sdk/-/sdk-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rocket.chat/sdk/-/sdk-0.1.0.tgz",
       "integrity": "sha1-uFcXq9gf1bSFcm62tgno8bUKuBg=",
       "requires": {
         "@types/lru-cache": "^4.1.0",
         "@types/node": "^9.4.6",
-        "asteroid": "github:rocketchat/asteroid",
+        "asteroid": "github:rocketchat/asteroid#a76a53254e381f9487aa2a9be3d874c9a2df6552",
         "lru-cache": "^4.1.1"
       }
     },
     "@slack/client": {
       "version": "3.16.1-sec.2",
       "resolved": "https://registry.npmjs.org/@slack/client/-/client-3.16.1-sec.2.tgz",
-      "integrity": "sha1-HC7f7IvdSZlJ6dq4SC2mP3q4qrs=",
+      "integrity": "sha512-FAERJJAurczrvgShW+9V95NdVYgf8FdIexUqfBgNuToRrLRDRcWNf0nGyfKAvl2RH1ncppzJp3iXgMNJFnJXhQ==",
       "requires": {
         "async": "^1.5.0",
         "bluebird": "^3.3.3",
@@ -394,21 +244,35 @@
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-          "integrity": "sha1-fQHG+WFsmlGrD4xUmnnf5uwz76c="
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+        },
+        "url-join": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+          "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g="
+        },
+        "ws": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
         }
       }
     },
     "@types/async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.1.tgz",
-      "integrity": "sha1-Q8Oyxg6rQcJcoACcB8p9YZ2UMRk="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.2.tgz",
+      "integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
     },
     "@types/body-parser": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-      "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -417,20 +281,20 @@
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g="
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
     "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
-      "integrity": "sha1-11a9GoXDTYfq9EyIi60nuopLfPA=",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -438,65 +302,77 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.2.tgz",
-      "integrity": "sha1-XuiiLmAgBb5nZ99rLLqYed8/dao=",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.1.tgz",
+      "integrity": "sha512-9e7jj549ZI+RxY21Cl0t8uBnWyb22HzILupyHZjYEVK//5TT/1bZodU+yUbLnPdoYViBBnNWbxp4zYjGV0zUGw==",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
       }
     },
     "@types/form-data": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
+      "integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
       "requires": {
-        "@types/node": "*"
+        "form-data": "*"
       }
     },
     "@types/jsonwebtoken": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
-      "integrity": "sha1-jRmdq03bW7oyNPgxG4BNICevKzo=",
+      "integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-sth6Xj341LGMpCbFEFzXAcIwbUA="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-ve2IoUJClE+4S/sG2zoLGEHP6DCvqgyz7UkHZdiICdQaAYRaCXsRWfJlbL8B0KvUyo9lgzD+oR0YSy4YikFyFQ=="
     },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50="
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "9.6.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.36.tgz",
-      "integrity": "sha1-xKK9sW06ebNOAUZLS9OMG4Se/aw="
+      "version": "9.6.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.55.tgz",
+      "integrity": "sha512-e/5tg8Ok0gSrN6pvHphnwTK0/CD9VPZrtZqpvvpEFAtfs+ZntusgGaWkf2lSEq1OFe2EDPeUMiMVpy4nZpJ4AQ=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/request": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
-      "integrity": "sha1-5ALWkapmcPu/8ZV7FfEnAjCrQvo=",
+      "version": "2.48.4",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
+      "integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
       "requires": {
         "@types/caseless": "*",
-        "@types/form-data": "*",
         "@types/node": "*",
-        "@types/tough-cookie": "*"
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
@@ -505,17 +381,17 @@
     "@types/sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha1-pPy4THNE859w3E7sDh5/EKSFl6M="
+      "integrity": "sha512-hkgzYF+qnIl8uTO8rmUSVSfQ8BIfMXC4yJAF4n8BE758YsKBZvFC4NumnAegj7KmylP0liEZNpb9RRGFMbFejA=="
     },
     "@types/tough-cookie": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha1-naRO11VxmZtlw3tgybK4jbVMWF0="
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
+      "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ=="
     },
     "@types/url-join": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.3.tgz",
-      "integrity": "sha1-E19AoBFA7TO1IoNume0g38EFYTc="
+      "integrity": "sha512-bM7dzLHuCqDNlbeOxvo/KfweN3La4d9C1VFGCgefxiZXn0JcRtyGDwWCSUEO8RrMhnx/LGhDOXP8TTokM1grSA=="
     },
     "abbrev": {
       "version": "1.0.9",
@@ -523,47 +399,36 @@
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
     },
     "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
       }
     },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk="
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "amdefine": {
@@ -582,7 +447,7 @@
     "ampersand-collection": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ampersand-collection/-/ampersand-collection-2.0.2.tgz",
-      "integrity": "sha1-fhk3T2d7mr0eLpd6eEVmqPexUwI=",
+      "integrity": "sha512-IjDa4HTL/tdQDDL0SGyWk4AHD02iNtUSLRWkAsJ2biPvapljW9HNgIEIdbPnnR+7Gb9BJkjesaLNjVZfAMzeuA==",
       "requires": {
         "ampersand-class-extend": "^2.0.0",
         "ampersand-events": "^2.0.1",
@@ -602,7 +467,7 @@
     "ampersand-state": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
-      "integrity": "sha1-M0AupgQ3WvZKJJ9mSgMSwRYNpHU=",
+      "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
       "requires": {
         "ampersand-events": "^2.0.1",
         "ampersand-version": "^1.0.0",
@@ -633,9 +498,16 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        }
       }
     },
     "array-flatten": {
@@ -654,9 +526,12 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -675,11 +550,21 @@
         "ddp.js": "^0.5.0",
         "faye-websocket": "^0.11.0",
         "q": "^1.0.1"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        }
       }
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "asynckit": {
@@ -693,27 +578,14 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
     "axios": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.7.0.tgz",
       "integrity": "sha1-SJwmkETVBm36LGTHScsTGxdvSno="
-    },
-    "babel-eslint": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
-      "integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
-      }
     },
     "babel-polyfill": {
       "version": "6.26.0",
@@ -754,25 +626,24 @@
     "base62": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
-      "integrity": "sha1-EmTLD7hI2HV5KHdHnb6LrmuuNCg="
+      "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
     },
     "base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha1-Y5nVcuK8P5CpqLItXbsKMtM/eI0="
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
       "version": "0.9.5",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "requires": {
         "readable-stream": "~1.0.26"
@@ -780,51 +651,62 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
-        "bytes": "3.0.0",
+        "bytes": "3.1.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
       },
       "dependencies": {
         "http-errors": {
-          "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
           }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "2.x.x"
       }
     },
     "botbuilder": {
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.16.0.tgz",
-      "integrity": "sha1-cA6jkYksYm+h+SJojSx0KwaE9QM=",
+      "integrity": "sha512-Gf51aNfvBuAxKSXQ+1SV/P1lzuRMyMyIqvjUUSqpjbtW6lFkPHhCmJIM0Dgxbflq78EXXisIYZQgAqsUNYeVQQ==",
       "requires": {
         "@types/async": "^2.0.48",
         "@types/express": "^4.11.1",
@@ -843,118 +725,12 @@
         "rsa-pem-from-mod-exp": "^0.8.4",
         "sprintf-js": "^1.0.3",
         "url-join": "^1.1.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "aws4": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-          "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
-          "requires": {
-            "ajv": "^6.5.5",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
-        },
-        "mime-db": {
-          "version": "1.38.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-          "integrity": "sha1-GiqrFtqesWe0nG5N8tnGjWPY4q0="
-        },
-        "mime-types": {
-          "version": "2.1.22",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-          "integrity": "sha1-/ms1WhkJJqt2mMmgVWoRGZshmb0=",
-          "requires": {
-            "mime-db": "~1.38.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        },
-        "url-join": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
-        }
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -973,37 +749,21 @@
     "buffer-indexof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow="
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-    },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "optional": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
-    },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -1011,13 +771,6 @@
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "charenc": {
@@ -1028,7 +781,7 @@
     "chrono-node": {
       "version": "1.3.11",
       "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.11.tgz",
-      "integrity": "sha1-uGomt+MVftzE/jN04bb5DK7cjjk=",
+      "integrity": "sha512-jDWRnY6nYvzfV3HPYBqo+tot7tcsUs9i3arGbMdI0TouPSXP2C2y/Ctp27rxKTQDi6yuTxAB2cw+Q6igGhOhdQ==",
       "requires": {
         "moment": "2.21.0"
       }
@@ -1062,30 +815,6 @@
       "resolved": "https://registry.npmjs.org/cline/-/cline-0.8.2.tgz",
       "integrity": "sha1-6RHnQaCtLiTSnm+rLPifoyLVnHY="
     },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "optional": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "optional": true
-        }
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "coffee-register": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/coffee-register/-/coffee-register-1.0.0.tgz",
@@ -1095,13 +824,6 @@
         "coffee-script": "^1.12.5",
         "fs-jetpack": "^0.13.3",
         "md5": "^2.2.1"
-      },
-      "dependencies": {
-        "coffee-script": {
-          "version": "1.12.7",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-          "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
-        }
       }
     },
     "coffee-script": {
@@ -1109,36 +831,23 @@
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commoner": {
       "version": "0.10.8",
@@ -1164,7 +873,7 @@
     "connect-multiparty": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/connect-multiparty/-/connect-multiparty-2.2.0.tgz",
-      "integrity": "sha1-tJMkgtuimPgrilS3D7YOxdcjk8M=",
+      "integrity": "sha512-zKcpA7cuXGEhuw9Pz7JmVCFmp85jzGLGm/iiagXTwyEAJp4ypLPtRS/V4IGuGb9KjjrgHBs6P/gDCpZHnFzksA==",
       "requires": {
         "http-errors": "~1.7.0",
         "multiparty": "~4.2.1",
@@ -1174,19 +883,29 @@
       }
     },
     "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
     },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -1199,9 +918,9 @@
       "integrity": "sha1-E6FHGFGKX8fMYjs/D0r4ee7X8c8="
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha1-+XJgj/DOrWi4QaFqky0LGDeRgU4="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1214,26 +933,16 @@
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        }
+        "boom": "2.x.x"
       }
     },
     "ctype": {
       "version": "0.5.3",
-      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
     },
     "cycle": {
@@ -1257,16 +966,17 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1296,35 +1006,40 @@
     "detective": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha1-DspzFDOEQv67bWXaVMELscgrJG4=",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "requires": {
         "acorn": "^5.2.1",
         "defined": "^1.0.0"
       }
     },
     "detectrtc": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/detectrtc/-/detectrtc-1.3.7.tgz",
-      "integrity": "sha1-3U8DEBvk3KfZqEeRWDcswyK0NvY="
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/detectrtc/-/detectrtc-1.3.9.tgz",
+      "integrity": "sha512-uDmANQib8St/dRppyQGXHX36qG2wel5dKHslqz0qr2958rcpN6heOzofV2PoKi7ogtCXpQuz0JUzazWhnLBPcA=="
     },
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1349,13 +1064,13 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha1-2m0NVpLvtGHggsFIF/4kJ9j10FQ="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -1381,53 +1096,23 @@
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.2.0"
-      }
-    },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
       },
       "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
-    },
-    "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-    },
-    "esprima-fb": {
-      "version": "15001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
-    },
-    "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "requires": {
-        "estraverse": "^4.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
-        }
-      }
     },
     "estraverse": {
       "version": "1.9.3",
@@ -1435,9 +1120,9 @@
       "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -1458,53 +1143,58 @@
       }
     },
     "express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha1-/d72GSYQniTFFeqX/S8b2/Yt8S4=",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
         "content-type": "~1.0.4",
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~1.1.2",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
-        "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -1517,14 +1207,14 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1532,9 +1222,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "faye-websocket": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
@@ -1549,28 +1239,21 @@
     },
     "file-type": {
       "version": "3.9.0",
-      "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha1-7r9O2EAHnIP0JJA4ydcDAIMBsQU=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
-      },
-      "dependencies": {
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
-        }
       }
     },
     "find-root": {
@@ -1598,11 +1281,11 @@
           "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
         },
         "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "^4.17.14"
           }
         },
         "aws-sign2": {
@@ -1610,35 +1293,19 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
           "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
         },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
         "caseless": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
           "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk="
         },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
         "extend": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
-          "integrity": "sha1-G3SYVAAXG4VVSJRFnJeN5u9FOrc="
+          "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
         },
         "form-data": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
           "requires": {
             "async": "^2.0.1",
@@ -1647,18 +1314,18 @@
           },
           "dependencies": {
             "mime-types": {
-              "version": "2.1.21",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-              "integrity": "sha1-KJlaoey3cHQv5q5+WPkYHHRLP5Y=",
+              "version": "2.1.26",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+              "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
               "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "1.43.0"
               }
             }
           }
         },
         "har-validator": {
           "version": "1.8.0",
-          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
           "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
           "requires": {
             "bluebird": "^2.9.30",
@@ -1666,22 +1333,6 @@
             "commander": "^2.8.1",
             "is-my-json-valid": "^2.12.0"
           }
-        },
-        "hawk": {
-          "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "http-signature": {
           "version": "0.11.0",
@@ -1693,14 +1344,9 @@
             "ctype": "0.5.3"
           }
         },
-        "mime-db": {
-          "version": "1.37.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-          "integrity": "sha1-C2oM5v2+lXbiXx8tL96IMNwK0Ng="
-        },
         "mime-types": {
           "version": "2.0.14",
-          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "requires": {
             "mime-db": "~1.12.0"
@@ -1708,10 +1354,20 @@
           "dependencies": {
             "mime-db": {
               "version": "1.12.0",
-              "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
               "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
             }
           }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
         "qs": {
           "version": "3.1.0",
@@ -1720,7 +1376,7 @@
         },
         "request": {
           "version": "2.58.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.58.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
           "integrity": "sha1-tfScC5Sqt/rTiGEqH7atA7bMFYA=",
           "requires": {
             "aws-sign2": "~0.5.0",
@@ -1744,27 +1400,11 @@
             "tunnel-agent": "~0.4.0"
           }
         },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
         "tunnel-agent": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
-      }
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
-      "requires": {
-        "is-callable": "^1.1.3"
       }
     },
     "forever-agent": {
@@ -1773,12 +1413,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -1803,7 +1443,7 @@
     "generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "requires": {
         "is-property": "^1.0.2"
       }
@@ -1837,42 +1477,34 @@
       }
     },
     "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "requires": {
         "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "process": "^0.11.10"
       }
     },
-    "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-    },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.0.tgz",
+      "integrity": "sha512-PaZ6G6nYzfJ0Hd1WIhOpsnUPWh1R0Pg//r4wEYOtzG65c2V8RJQ/++yYlVmuoQ7EMXcb4eri5+FB2XH1Lwed9g==",
       "requires": {
-        "async": "^1.4.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -1882,11 +1514,11 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       }
     },
@@ -1904,37 +1536,37 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "http-errors": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
-      "integrity": "sha1-ak/+XTUYjhw5+HJTRpBYWFLh8Cc=",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
       "requires": {
         "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
     },
     "http-parser-js": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.6.tgz",
-      "integrity": "sha1-GVJz9YcExFLWcQdr4gEyndNB3FU="
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1947,38 +1579,33 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
         }
       }
     },
     "hubot": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/hubot/-/hubot-3.1.1.tgz",
-      "integrity": "sha1-xuisEOPXABBD0GTFK26Uav1+p0k=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hubot/-/hubot-3.3.2.tgz",
+      "integrity": "sha512-+8h/s+t5GirjuDW5K1QjTGBGzOU8ksEi51HeLdFghYOWj40x6ndhAU3C6SRPk/7yHj6luVPuVi/Y8s0P+lqM9Q==",
       "requires": {
         "async": ">=0.1.0 <1.0.0",
         "chalk": "^1.0.0",
         "cline": "^0.8.2",
-        "coffee-script": "1.6.3",
+        "coffeescript": "1.6.3",
         "connect-multiparty": "^2.1.1",
         "express": "^4.16.3",
         "log": "1.4.0",
@@ -1988,20 +1615,20 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
         },
-        "coffee-script": {
+        "coffeescript": {
           "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
-          "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4="
+          "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.6.3.tgz",
+          "integrity": "sha1-QXSXUMYhplU8fAOBilOEuyTDBUE="
         }
       }
     },
     "hubot-botframework": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/hubot-botframework/-/hubot-botframework-0.10.1.tgz",
-      "integrity": "sha1-hbtiPLkMHr8tMX0ZOwi4UJjPRa8=",
+      "integrity": "sha512-c9jMM/WmzmoQIBVtmLR0U39zNIkOW2X4cGbRkofcl+M8AmQPZVvD0dJ+xCYov9GtV/rBHyr03R9liL9fzDUdPg==",
       "requires": {
         "botbuilder": ">=3.5.0",
         "parent-require": "^1.0.0"
@@ -2033,1168 +1660,26 @@
         "node-xmpp-client": "^2.1.0",
         "rsvp": "~1.2.0",
         "underscore": "~1.4.4"
-      },
-      "dependencies": {
-        "node-xmpp-client": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-2.1.0.tgz",
-          "integrity": "sha1-i6fOmNrMhYadTRRrqq2H5SM2Ilg=",
-          "requires": {
-            "browser-request": "^0.3.3",
-            "debug": "^2.2.0",
-            "faye-websocket": "^0.10.0",
-            "istanbul": "^0.4.0",
-            "minimist": "^1.2.0",
-            "node-xmpp-core": "^4.1.0",
-            "request": "^2.65.0"
-          },
-          "dependencies": {
-            "browser-request": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-              "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
-            },
-            "debug": {
-              "version": "2.6.8",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-              "requires": {
-                "ms": "2.0.0"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                }
-              }
-            },
-            "faye-websocket": {
-              "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-              "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-              "requires": {
-                "websocket-driver": ">=0.5.1"
-              },
-              "dependencies": {
-                "websocket-driver": {
-                  "version": "0.6.5",
-                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-                  "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-                  "requires": {
-                    "websocket-extensions": ">=0.1.1"
-                  },
-                  "dependencies": {
-                    "websocket-extensions": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-                      "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec="
-                    }
-                  }
-                }
-              }
-            },
-            "istanbul": {
-              "version": "0.4.5",
-              "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-              "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-              "requires": {
-                "abbrev": "1.0.x",
-                "async": "1.x",
-                "escodegen": "1.8.x",
-                "esprima": "2.7.x",
-                "glob": "^5.0.15",
-                "handlebars": "^4.0.1",
-                "js-yaml": "3.x",
-                "mkdirp": "0.5.x",
-                "nopt": "3.x",
-                "once": "1.x",
-                "resolve": "1.1.x",
-                "supports-color": "^3.1.0",
-                "which": "^1.1.1",
-                "wordwrap": "^1.0.0"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
-                },
-                "async": {
-                  "version": "1.5.2",
-                  "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-                },
-                "escodegen": {
-                  "version": "1.8.1",
-                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-                  "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-                  "requires": {
-                    "esprima": "^2.7.1",
-                    "estraverse": "^1.9.1",
-                    "esutils": "^2.0.2",
-                    "optionator": "^0.8.1",
-                    "source-map": "~0.2.0"
-                  },
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "1.9.3",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-                    },
-                    "optionator": {
-                      "version": "0.8.2",
-                      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-                      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-                      "requires": {
-                        "deep-is": "~0.1.3",
-                        "fast-levenshtein": "~2.0.4",
-                        "levn": "~0.3.0",
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2",
-                        "wordwrap": "~1.0.0"
-                      },
-                      "dependencies": {
-                        "deep-is": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-                        },
-                        "fast-levenshtein": {
-                          "version": "2.0.6",
-                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-                        },
-                        "levn": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-                          "requires": {
-                            "prelude-ls": "~1.1.2",
-                            "type-check": "~0.3.2"
-                          }
-                        },
-                        "prelude-ls": {
-                          "version": "1.1.2",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-                        },
-                        "type-check": {
-                          "version": "0.3.2",
-                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                          "requires": {
-                            "prelude-ls": "~1.1.2"
-                          }
-                        }
-                      }
-                    },
-                    "source-map": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-                      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-                      "optional": true,
-                      "requires": {
-                        "amdefine": ">=0.0.4"
-                      },
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                  "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-                },
-                "glob": {
-                  "version": "5.0.15",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                  "requires": {
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "2 || 3",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                      "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-                      "requires": {
-                        "brace-expansion": "^1.1.7"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                          "requires": {
-                            "balanced-match": "^1.0.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-                    }
-                  }
-                },
-                "handlebars": {
-                  "version": "4.0.10",
-                  "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-                  "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-                  "requires": {
-                    "async": "^1.4.0",
-                    "optimist": "^0.6.1",
-                    "source-map": "^0.4.4",
-                    "uglify-js": "^2.6"
-                  },
-                  "dependencies": {
-                    "optimist": {
-                      "version": "0.6.1",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-                      "requires": {
-                        "minimist": "~0.0.1",
-                        "wordwrap": "~0.0.2"
-                      },
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.10",
-                          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-                        },
-                        "wordwrap": {
-                          "version": "0.0.3",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-                        }
-                      }
-                    },
-                    "source-map": {
-                      "version": "0.4.4",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                      "requires": {
-                        "amdefine": ">=0.0.4"
-                      },
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-                        }
-                      }
-                    },
-                    "uglify-js": {
-                      "version": "2.8.29",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                      "optional": true,
-                      "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
-                      },
-                      "dependencies": {
-                        "source-map": {
-                          "version": "0.5.6",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-                          "optional": true
-                        },
-                        "uglify-to-browserify": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-                          "optional": true
-                        },
-                        "yargs": {
-                          "version": "3.10.0",
-                          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                          "optional": true,
-                          "requires": {
-                            "camelcase": "^1.0.2",
-                            "cliui": "^2.1.0",
-                            "decamelize": "^1.0.0",
-                            "window-size": "0.1.0"
-                          },
-                          "dependencies": {
-                            "camelcase": {
-                              "version": "1.2.1",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                              "optional": true
-                            },
-                            "cliui": {
-                              "version": "2.1.0",
-                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                              "optional": true,
-                              "requires": {
-                                "center-align": "^0.1.1",
-                                "right-align": "^0.1.1",
-                                "wordwrap": "0.0.2"
-                              },
-                              "dependencies": {
-                                "center-align": {
-                                  "version": "0.1.3",
-                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                                  "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-                                  "optional": true,
-                                  "requires": {
-                                    "align-text": "^0.1.3",
-                                    "lazy-cache": "^1.0.3"
-                                  },
-                                  "dependencies": {
-                                    "align-text": {
-                                      "version": "0.1.4",
-                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                                      "optional": true,
-                                      "requires": {
-                                        "kind-of": "^3.0.2",
-                                        "longest": "^1.0.1",
-                                        "repeat-string": "^1.5.2"
-                                      },
-                                      "dependencies": {
-                                        "kind-of": {
-                                          "version": "3.2.2",
-                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                          "optional": true,
-                                          "requires": {
-                                            "is-buffer": "^1.1.5"
-                                          },
-                                          "dependencies": {
-                                            "is-buffer": {
-                                              "version": "1.1.5",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-                                              "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-                                              "optional": true
-                                            }
-                                          }
-                                        },
-                                        "longest": {
-                                          "version": "1.0.1",
-                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                          "optional": true
-                                        },
-                                        "repeat-string": {
-                                          "version": "1.6.1",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                                          "optional": true
-                                        }
-                                      }
-                                    },
-                                    "lazy-cache": {
-                                      "version": "1.0.4",
-                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                                      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "right-align": {
-                                  "version": "0.1.3",
-                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                                  "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-                                  "optional": true,
-                                  "requires": {
-                                    "align-text": "^0.1.1"
-                                  },
-                                  "dependencies": {
-                                    "align-text": {
-                                      "version": "0.1.4",
-                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                                      "optional": true,
-                                      "requires": {
-                                        "kind-of": "^3.0.2",
-                                        "longest": "^1.0.1",
-                                        "repeat-string": "^1.5.2"
-                                      },
-                                      "dependencies": {
-                                        "kind-of": {
-                                          "version": "3.2.2",
-                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                          "optional": true,
-                                          "requires": {
-                                            "is-buffer": "^1.1.5"
-                                          },
-                                          "dependencies": {
-                                            "is-buffer": {
-                                              "version": "1.1.5",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-                                              "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-                                              "optional": true
-                                            }
-                                          }
-                                        },
-                                        "longest": {
-                                          "version": "1.0.1",
-                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                          "optional": true
-                                        },
-                                        "repeat-string": {
-                                          "version": "1.6.1",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                                          "optional": true
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "wordwrap": {
-                                  "version": "0.0.2",
-                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                                  "optional": true
-                                }
-                              }
-                            },
-                            "decamelize": {
-                              "version": "1.2.0",
-                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-                              "optional": true
-                            },
-                            "window-size": {
-                              "version": "0.1.0",
-                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                              "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "js-yaml": {
-                  "version": "3.9.0",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-                  "integrity": "sha1-T/u/JcKsljuCmdx02n43QN4cGM4=",
-                  "requires": {
-                    "argparse": "^1.0.7",
-                    "esprima": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "argparse": {
-                      "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-                      "requires": {
-                        "sprintf-js": "~1.0.2"
-                      },
-                      "dependencies": {
-                        "sprintf-js": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "4.0.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-                      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                  "requires": {
-                    "minimist": "0.0.8"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.6",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-                  "requires": {
-                    "abbrev": "1"
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "requires": {
-                    "wrappy": "1"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                    }
-                  }
-                },
-                "resolve": {
-                  "version": "1.1.7",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                  "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-                },
-                "supports-color": {
-                  "version": "3.2.3",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                  "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                  "requires": {
-                    "has-flag": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-                    }
-                  }
-                },
-                "which": {
-                  "version": "1.2.14",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-                  "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-                  "requires": {
-                    "isexe": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "isexe": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-                      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-                    }
-                  }
-                },
-                "wordwrap": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                  "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            },
-            "node-xmpp-core": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/node-xmpp-core/-/node-xmpp-core-4.2.0.tgz",
-              "integrity": "sha1-fi4EDB5apkvjUBO9w0Ey7Ddpla4=",
-              "requires": {
-                "debug": "^2.2.0",
-                "inherits": "^2.0.1",
-                "lodash.assign": "^3.2.0",
-                "ltx": "^2.0.1",
-                "node-xmpp-jid": "^2.0.0",
-                "reconnect-core": "https://github.com/dodo/reconnect-core/tarball/merged",
-                "tls-connect": "^0.2.2"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                },
-                "lodash.assign": {
-                  "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-                  "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-                  "requires": {
-                    "lodash._baseassign": "^3.0.0",
-                    "lodash._createassigner": "^3.0.0",
-                    "lodash.keys": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "lodash._baseassign": {
-                      "version": "3.2.0",
-                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-                      "requires": {
-                        "lodash._basecopy": "^3.0.0",
-                        "lodash.keys": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "lodash._basecopy": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-                        }
-                      }
-                    },
-                    "lodash._createassigner": {
-                      "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-                      "requires": {
-                        "lodash._bindcallback": "^3.0.0",
-                        "lodash._isiterateecall": "^3.0.0",
-                        "lodash.restparam": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "lodash._bindcallback": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-                          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-                        },
-                        "lodash._isiterateecall": {
-                          "version": "3.0.9",
-                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-                        },
-                        "lodash.restparam": {
-                          "version": "3.6.1",
-                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-                        }
-                      }
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.2",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-                      "requires": {
-                        "lodash._getnative": "^3.0.0",
-                        "lodash.isarguments": "^3.0.0",
-                        "lodash.isarray": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.1.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-                        },
-                        "lodash.isarray": {
-                          "version": "3.0.4",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-                        }
-                      }
-                    }
-                  }
-                },
-                "ltx": {
-                  "version": "2.7.1",
-                  "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
-                  "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
-                  "requires": {
-                    "inherits": "^2.0.1"
-                  }
-                },
-                "node-xmpp-jid": {
-                  "version": "2.3.0",
-                  "resolved": "https://registry.npmjs.org/node-xmpp-jid/-/node-xmpp-jid-2.3.0.tgz",
-                  "integrity": "sha1-YKPJUFgqDNz9oHRJQ1eoUXjziHg="
-                },
-                "reconnect-core": {
-                  "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-                  "integrity": "sha1-udryrcRbGabMX9LwSPjZQGzs5Jg=",
-                  "requires": {
-                    "backoff": "~2.3.0"
-                  },
-                  "dependencies": {
-                    "backoff": {
-                      "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
-                      "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
-                    }
-                  }
-                },
-                "tls-connect": {
-                  "version": "0.2.2",
-                  "resolved": "https://registry.npmjs.org/tls-connect/-/tls-connect-0.2.2.tgz",
-                  "integrity": "sha1-HYjU9MuCmgdBtqzQXR33Pg1Wb9A="
-                }
-              }
-            },
-            "request": {
-              "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-              "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-                },
-                "aws4": {
-                  "version": "1.6.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-                },
-                "caseless": {
-                  "version": "0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                  "requires": {
-                    "delayed-stream": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-                },
-                "form-data": {
-                  "version": "2.1.4",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                  "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
-                  },
-                  "dependencies": {
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                  "requires": {
-                    "ajv": "^4.9.1",
-                    "har-schema": "^1.0.5"
-                  },
-                  "dependencies": {
-                    "ajv": {
-                      "version": "4.11.8",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                      "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "co": {
-                          "version": "4.6.0",
-                          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-                        },
-                        "json-stable-stringify": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-                          "requires": {
-                            "jsonify": "~0.0.0"
-                          },
-                          "dependencies": {
-                            "jsonify": {
-                              "version": "0.0.0",
-                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "har-schema": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                  "requires": {
-                    "boom": "2.x.x",
-                    "cryptiles": "2.x.x",
-                    "hoek": "2.x.x",
-                    "sntp": "1.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                      "requires": {
-                        "boom": "2.x.x"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                      "requires": {
-                        "hoek": "2.x.x"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                  "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-                    },
-                    "jsprim": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                        },
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-                        },
-                        "json-schema": {
-                          "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.13.1",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-                      "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                          "optional": true,
-                          "requires": {
-                            "tweetnacl": "^0.14.3"
-                          }
-                        },
-                        "dashdash": {
-                          "version": "1.14.1",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "~0.1.0"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.7",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                          "requires": {
-                            "assert-plus": "^1.0.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.5",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-                },
-                "mime-types": {
-                  "version": "2.1.15",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-                  "requires": {
-                    "mime-db": "~1.27.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-                },
-                "performance-now": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-                },
-                "qs": {
-                  "version": "6.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                  "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-                  "requires": {
-                    "punycode": "^1.4.1"
-                  },
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-                    }
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                  "requires": {
-                    "safe-buffer": "^5.0.1"
-                  }
-                },
-                "uuid": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-                  "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
-                }
-              }
-            }
-          }
-        },
-        "rsvp": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/rsvp/-/rsvp-1.2.0.tgz",
-          "integrity": "sha1-CXoAGzAmwXJo0Xnex0K5nKYfqFM="
-        },
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
-        }
       }
     },
     "hubot-irc": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.0.tgz",
-      "integrity": "sha1-qV1cMshnAtljJOgnZWrUV65fT1o=",
+      "integrity": "sha512-fyK6YKBc/rJnwtWyt6ke92JpxfqdPn8rkl8ArKvhhXLu0SC+UmcLuddNNccLnSte0PbF016fQnZkEGGYbH6uvQ==",
       "requires": {
         "irc": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
         "log": "1.4.0"
       }
     },
     "hubot-matteruser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.2.0.tgz",
-      "integrity": "sha1-YeDZDemcwS4QC5HpyTJGPSggZl0=",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.3.1.tgz",
+      "integrity": "sha512-T3QEisQV0iNYihN6XQF7UF4DP40KH2/9scCHtvW+sMj7j18Iiokg3i3tWZF8zoksgV2eN3UDUWpIb1rnFScaIQ==",
       "requires": {
-        "mattermost-client": "^6.1.0",
+        "mattermost-client": "^6.1.1",
         "parent-require": "^1.0.0",
-        "q": "^1.4.1"
+        "q": "^1.4.1",
+        "ws": ">=3.3.1"
       }
     },
     "hubot-redis-brain": {
@@ -3203,35 +1688,6 @@
       "integrity": "sha1-kYLFd1YAZbNKBaLqHdq6Ix0JMCM=",
       "requires": {
         "redis": "~2.6.x"
-      },
-      "dependencies": {
-        "redis": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
-          "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
-          "requires": {
-            "double-ended-queue": "^2.1.0-0",
-            "redis-commands": "^1.2.0",
-            "redis-parser": "^2.0.0"
-          },
-          "dependencies": {
-            "double-ended-queue": {
-              "version": "2.1.0-0",
-              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
-            },
-            "redis-commands": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-              "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
-            },
-            "redis-parser": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-              "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
-            }
-          }
-        }
       }
     },
     "hubot-rocketchat": {
@@ -3259,9 +1715,9 @@
       }
     },
     "hubot-slack": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/hubot-slack/-/hubot-slack-4.5.5.tgz",
-      "integrity": "sha1-1s+/RaiODeGPJXDcun3ak5lG2oI=",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/hubot-slack/-/hubot-slack-4.7.1.tgz",
+      "integrity": "sha512-ieQdGv0XgdhAWjIvoY3UPi05AKV3d6XZYClX/xWGfGmK5tLFX3ZPLjJyJ6dKIXWXke7/kE47HqSACZskrt0Mcg==",
       "requires": {
         "@slack/client": "3.16.1-sec.2",
         "bluebird": "^3.5.1",
@@ -3269,9 +1725,9 @@
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-          "integrity": "sha1-fQHG+WFsmlGrD4xUmnnf5uwz76c="
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
         }
       }
     },
@@ -3287,17 +1743,16 @@
       "dependencies": {
         "request": {
           "version": "2.9.3",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.9.3.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.9.3.tgz",
           "integrity": "sha1-rArCYWlWiDfSiGqSsiwL0eFeetc="
         }
       }
     },
     "hubot-stackstorm": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/hubot-stackstorm/-/hubot-stackstorm-0.9.6.tgz",
-      "integrity": "sha512-WNQOU9FWKII4tAUiYzXaz+n/a5icwQ7xmUzR+bAEIV3HpzO3i4ZtKuNDG7XgK2PRNB833fJKQbHki7YJKE8HRQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/hubot-stackstorm/-/hubot-stackstorm-0.10.1.tgz",
+      "integrity": "sha512-WBrjagzJbmuz0X6I5bhY8X2VRlpVLp8+mdeSM9WjRL6SuGZB9RvjYGPzOt27Im/GT+03BDw0uaCinvZxREsFiw==",
       "requires": {
-        "babel-eslint": "^10.0.1",
         "cli-table": "<=1.0.0",
         "coffee-register": "1.0.0",
         "coffee-script": "1.12.7",
@@ -3306,20 +1761,41 @@
         "st2client": "^1.1.3",
         "truncate": "^2.0.1",
         "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+        }
       }
     },
     "hubot-xmpp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/hubot-xmpp/-/hubot-xmpp-0.2.5.tgz",
-      "integrity": "sha1-/8PfqqejTVSz2SPqcWcRLErcnB0=",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/hubot-xmpp/-/hubot-xmpp-0.2.6.tgz",
+      "integrity": "sha512-JqByL+unUz0WZYp0Miovr7iiHwkgISJLMiL9FBEdovYZwsSmZegixyqm0y5L7bIklz57J2oIs/jrY0DitKCt/A==",
       "requires": {
         "node-xmpp-client": "3.0.0",
         "uuid": "2.0.2"
       },
       "dependencies": {
+        "node-xmpp-client": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.0.0.tgz",
+          "integrity": "sha1-UsxdO/fR/IbSd2pYL3x7yugCYTo=",
+          "requires": {
+            "browser-request": "^0.3.3",
+            "debug": "^2.2.0",
+            "faye-websocket": "^0.10.0",
+            "istanbul": "^0.4.0",
+            "minimist": "^1.2.0",
+            "node-xmpp-core": "^4.1.0",
+            "request": "^2.65.0"
+          }
+        },
         "uuid": {
           "version": "2.0.2",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
           "integrity": "sha1-SL1WmPBnfjx5AaHEbvFbFkN5RyY="
         }
       }
@@ -3334,9 +1810,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -3351,17 +1827,17 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ipaddr.js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "irc": {
-      "version": "git://github.com/matrix-org/node-irc.git#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
+      "version": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
       "from": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
       "requires": {
         "iconv": "~2.2.1",
@@ -3370,19 +1846,14 @@
       }
     },
     "irc-colors": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.4.3.tgz",
-      "integrity": "sha1-hAsGsYYopnYOaOS1FMcQ1Ulkiu8="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.5.0.tgz",
+      "integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-    },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-function": {
       "version": "1.0.1",
@@ -3392,12 +1863,12 @@
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ="
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
     },
     "is-my-json-valid": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha1-j9bkA2PNBrlj+od9REv7Xt3GIXU=",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -3450,39 +1921,38 @@
         "supports-color": "^3.1.0",
         "which": "^1.1.1",
         "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         }
       }
     },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3490,9 +1960,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -3507,7 +1977,7 @@
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -3519,13 +1989,6 @@
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
         "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
-        }
       }
     },
     "jsprim": {
@@ -3551,6 +2014,11 @@
         "source-map": "^0.4.2"
       },
       "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+        },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -3564,7 +2032,7 @@
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3574,7 +2042,7 @@
     "jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -3584,21 +2052,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/key-tree-store/-/key-tree-store-1.3.0.tgz",
       "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "optional": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "optional": true
     },
     "levn": {
       "version": "0.3.0",
@@ -3610,9 +2063,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -3725,42 +2178,37 @@
     },
     "log": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/log/-/log-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
       "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
-    },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
     },
     "ltx": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
-      "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
+      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4"
       }
     },
     "mattermost-client": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.1.0.tgz",
-      "integrity": "sha1-cw5BLw8BTvq2GiHbKN8S8gqIgSY=",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.1.2.tgz",
+      "integrity": "sha512-kVEwD1oSepktOKFO5PGHxdKG6Yc9Pzo9zDIiGj5PiYn6P4z2s/PrTJX1lhf6flORaONTOfyMVbP3aexlHKNTEA==",
       "requires": {
+        "extend": "^3.0.2",
         "https-proxy-agent": "^2.1.0",
         "log": "^1.4.0",
-        "request": "^2.73.0",
+        "request": "^2.88.0",
         "text-encoding": "^0.5.5",
-        "ws": "^1.0.1"
+        "ws": ">=3.3.1"
       }
     },
     "md5": {
@@ -3775,7 +2223,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
@@ -3789,21 +2237,21 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.43.0"
       }
     },
     "min-document": {
@@ -3817,19 +2265,19 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3837,7 +2285,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -3845,34 +2293,46 @@
     "moment": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha1-KhFLUdKm7J5tg8+AP4OKh42KAjo="
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiparty": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.2.1.tgz",
-      "integrity": "sha1-2bbEbYuN6rHucMc0sK93HdRuCxM=",
+      "integrity": "sha512-AvESCnNoQlZiOfP9R4mxN8M9csy2L16EIbWIkt3l4FuGti9kXBS8QVzlfyg4HEnarJhrzZilgNFlZtqmoiAIIA==",
       "requires": {
         "fd-slicer": "1.1.0",
         "http-errors": "~1.7.0",
         "safe-buffer": "5.1.2",
         "uid-safe": "2.1.5"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha1-kOIrzLjKV+pM03zIPTgZtS7qZ2Y=",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "node-icu-charset-detector": {
       "version": "0.2.0",
@@ -3883,15 +2343,10 @@
         "nan": "^2.3.3"
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "node-xmpp-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.0.0.tgz",
-      "integrity": "sha1-UsxdO/fR/IbSd2pYL3x7yugCYTo=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-2.1.0.tgz",
+      "integrity": "sha1-i6fOmNrMhYadTRRrqq2H5SM2Ilg=",
       "requires": {
         "browser-request": "^0.3.3",
         "debug": "^2.2.0",
@@ -3900,16 +2355,6 @@
         "minimist": "^1.2.0",
         "node-xmpp-core": "^4.1.0",
         "request": "^2.65.0"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        }
       }
     },
     "node-xmpp-core": {
@@ -3940,9 +2385,9 @@
       }
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "2.1.1",
@@ -3989,7 +2434,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
@@ -4000,16 +2445,16 @@
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "options": {
@@ -4036,18 +2481,14 @@
       "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
     },
     "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
-      "requires": {
-        "for-each": "^0.3.2",
-        "trim": "0.0.1"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
     },
     "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4087,28 +2528,28 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
       }
     },
     "proxy-addr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha1-7PxzO/Iv+Mb0B/onUye5q2fki5M=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.8.0"
+        "ipaddr.js": "1.9.0"
       }
     },
     "pseudomap": {
@@ -4117,14 +2558,14 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -4134,7 +2575,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystringify": {
       "version": "2.1.1",
@@ -4147,37 +2588,43 @@
       "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha1-GzJOzmtXBuFThVvBFIxlu39uoMM=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
       "dependencies": {
         "http-errors": {
-          "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
           }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -4201,59 +2648,78 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "reconnect-core": {
       "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-      "integrity": "sha1-udryrcRbGabMX9LwSPjZQGzs5Jg=",
+      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
       "requires": {
         "backoff": "~2.3.0"
       }
     },
+    "redis": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
+      "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "optional": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha1-WgNhWkfGFCCz65m326IE+DYD4fo=",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "requires-port": {
@@ -4271,34 +2737,25 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
       "integrity": "sha1-b2l+UKDk3cjI9/tUeptg3q1DZ40="
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
     "rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-1.2.0.tgz",
+      "integrity": "sha1-CXoAGzAmwXJo0Xnex0K5nKYfqFM="
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "scoped-http-client": {
       "version": "0.11.0",
@@ -4311,19 +2768,19 @@
       "integrity": "sha1-jgOPbdsUvXZa4fS1IW4SCUUR4NA="
     },
     "sdp-transform": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.5.0.tgz",
-      "integrity": "sha1-SCmm156FTRoCLku8a75D7Mw+9iQ="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.13.0.tgz",
+      "integrity": "sha512-3zT7pcjR090E0WCV9eOtFX06iojoNKsyMXqXs7clOs8sy+RoegR0cebmCuCrTKdY2jw1XhT9jkraygJrqAUwzA=="
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -4332,74 +2789,59 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
     "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
-        "send": "0.16.2"
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "2.x.x"
       }
     },
     "source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-      "optional": true,
-      "requires": {
-        "amdefine": ">=0.0.4"
-      }
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4408,16 +2850,18 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
     "st2client": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/st2client/-/st2client-1.1.3.tgz",
-      "integrity": "sha512-YUMlFXRENID5OFQnbSU4zIP/oT0+DNZhVXSupPmu+6XdsSWSqu+apY8noo66iZ2Yhz4S+vjaB241q0frEQW+6Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/st2client/-/st2client-1.2.1.tgz",
+      "integrity": "sha512-7xZNyGNaL2ekoNJcSbishtpfOJ5p53oBcoZPfZTxywJC17iGbqrP09wRCPuFUtrkUReH+4dLC4GxgxCx/LLGWg==",
       "requires": {
         "axios": "^0.7.0",
         "eventsource": "^0.1.4",
+        "lodash": "^4.17.15",
         "object.assign": "^1.0.1"
       }
     },
@@ -4442,25 +2886,22 @@
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "requires": {
-        "has-flag": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "text-encoding": {
       "version": "0.5.5",
@@ -4469,12 +2910,12 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.6.5",
-      "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
@@ -4486,33 +2927,26 @@
       "resolved": "https://registry.npmjs.org/tls-connect/-/tls-connect-0.2.2.tgz",
       "integrity": "sha1-HYjU9MuCmgdBtqzQXR33Pg1Wb9A="
     },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
+        "psl": "^1.1.24",
         "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truncate": {
       "version": "2.1.0",
@@ -4530,8 +2964,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -4542,43 +2975,36 @@
       }
     },
     "type-is": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "~2.1.24"
       }
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+      "integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "commander": "~2.20.3",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "optional": true
         }
       }
     },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
-    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha1-Kz1cckDo/C5Y+Komnl7knAhXvTo=",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
       "requires": {
         "random-bytes": "~1.0.0"
       }
@@ -4588,6 +3014,11 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -4596,22 +3027,15 @@
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
-        }
       }
     },
     "url-join": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-parse": {
       "version": "1.4.7",
@@ -4633,9 +3057,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "vary": {
       "version": "1.1.2",
@@ -4661,37 +3085,32 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "requires": {
-        "http-parser-js": ">=0.4.0",
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
-      "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0="
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "optional": true
-    },
     "winston": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha1-oB5NHQoQPPTq2m/B+IazEQ1xw0s=",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",
@@ -4703,10 +3122,15 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -4719,35 +3143,19 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha1-y9nm514J/F0skAFfIfDECHXg3VE=",
-      "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "optional": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hubot-scripts": "^2.17.2",
     "hubot-slack": "^4.5.5",
     "hubot-spark": "^2.0.0",
-    "hubot-stackstorm": "^0.9.6",
+    "hubot-stackstorm": "^0.10.1",
     "hubot-xmpp": "^0.2.5"
   },
   "engines": {

--- a/packagingenv/centos8/Dockerfile
+++ b/packagingenv/centos8/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos:8
+
+RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
+
+RUN yum -y update
+
+# Install development tools
+RUN dnf -y module install nodejs:10
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packagingenv/centos8/Dockerfile
+++ b/packagingenv/centos8/Dockerfile
@@ -2,10 +2,11 @@ FROM centos:8
 
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
-RUN yum -y update
+# Add NodeSource repo
+RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
 
 # Install development tools
-RUN dnf -y module install nodejs:10
+RUN yum -y install nodejs
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packagingenv/centos8/docker-entrypoint.sh
+++ b/packagingenv/centos8/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+operation="${1:-build}"
+
+case "$operation" in
+pull)
+  ;;
+build)
+  rpmbuild -bb rpm/st2chatops.spec
+  cp ../*.rpm $ARTIFACT_DIR
+  ;;
+*)
+  [ $# -gt 0 ] && exec "$@"
+  ;;
+esac

--- a/testingenv/centos8/Dockerfile
+++ b/testingenv/centos8/Dockerfile
@@ -1,0 +1,10 @@
+FROM centos:8
+
+# Add NodeSource repo
+RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
+
+# Install development tools
+RUN yum -y install nodejs
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/testingenv/centos8/docker-entrypoint.sh
+++ b/testingenv/centos8/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+operation="${1:-test}"
+
+case "$operation" in
+pull)
+  ;;
+test)
+  rpm -i $ARTIFACT_DIR/*.rpm
+  cd /opt/stackstorm/chatops
+  sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
+  sed -i.bak -r "s/^(export ST2_AUTH_USERNAME.).*/\1$ST2_USERNAME/" st2chatops.env
+  sed -i.bak -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$ST2_PASSWORD/" st2chatops.env
+  bin/hubot &> /tmp/hubot.log &
+  sleep 15
+  cat /tmp/hubot.log
+  grep -rq "INFO Connected to Slack RTM" /tmp/hubot.log && \
+  grep -rq "INFO [[:digit:]]\+ commands are loaded" /tmp/hubot.log
+  exit $?
+  ;;
+*)
+  [ $# -gt 0 ] && exec "$@"
+  ;;
+esac

--- a/update.py
+++ b/update.py
@@ -136,7 +136,7 @@ class Suite(object):
         confpath = os.path.join(self.workdir, 'suite.yml')
         if os.path.isfile(confpath):
             fd = open(confpath, 'r')
-            for opt, value in yaml.load(fd).items():
+            for opt, value in yaml.load(fd, Loader=yaml.FullLoader).items():
                 if value:
                     setattr(self, opt, value)
             fd.close()
@@ -160,10 +160,10 @@ class Suite(object):
             sys.exit(1)
 
         fd = open(found, 'r')
-        data = (yaml.load(fd) or {})
+        data = yaml.load(fd, Loader=yaml.FullLoader) or {}
         fd.close()
         self.distmap_cache[found] = data
-        return (data or {})
+        return data or {}
 
     def process(self):
         curd = os.getcwd()
@@ -176,12 +176,12 @@ class Suite(object):
             for variant in self.variants:
                 # Variant is None what means default, so empty string
                 if variant is None:
-                    yield(self.suite_context(suite, ''))
+                    yield self.suite_context(suite, '')
                 else:
                     # Variant matches suite list of names or regexes
                     variant = match_and_fetch(suite, variant)
                     if variant:
-                        yield(self.suite_context(suite, variant))
+                        yield self.suite_context(suite, variant)
         os.chdir(curd)
 
     def suite_context(self, suite, variant):
@@ -204,12 +204,12 @@ class Suite(object):
             for str_or_regex in mappings:
                 ematch = eqauls_or_matches(suite, str_or_regex)
                 if ematch is True:
-                    return (dist, suite)
+                    return dist, suite
                 elif ematch:
-                    return (dist, ematch.group(1) or suite)
+                    return dist, ematch.group(1) or suite
         print("Warn: suite to dist mapping not found! Check dist.yml for `{}' mapping."
               .format(suite))
-        return ('', suite)
+        return '', suite
 
 
 def main():
@@ -239,10 +239,11 @@ def main():
                                          fromfile=target_abspath + '.~',
                                          tofile=target_abspath,
                                          lineterm='', n=0):
-            print line
+            print(line)
 
         fd.write("{}\n".format(rendered))
         fd.close()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* Added support for EL8
* Works fine, locally, but there are a bunch of node security issues. 
* most build are broken, not sure if this was the deal already, I can build locally fine.
* lots broken in circle. 
```
npm install --production
npm WARN babel-eslint@10.0.2 requires a peer of eslint@>= 4.12.1 but none is installed. You must install peer dependencies yourself.
npm WARN hubot-botframework@0.10.1 requires a peer of hubot@^2.19.0 but none is installed. You must install peer dependencies yourself.

audited 6575 packages in 8.185s
found 228 vulnerabilities (2 low, 56 moderate, 168 high, 2 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
npm cache verify && npm cache clean --force
```

cc @armab 