### PR TITLE
update perms in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 all: build
 
 build:
+	chown -R root:root /root/st2chatops/
 	npm install --production
 	npm cache verify && npm cache clean --force
 


### PR DESCRIPTION
* Made a change in Makefile to chown the `/root/st2chatops` to be owned by root:root fixing the breaking `npm --install` perms issues in current builds