### PR TITLE
Fix the nodejs build: update perms in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 all: build
 
 build:
+	chown -R root:root /root/st2chatops/
 	npm install --production
 	npm cache verify && npm cache clean --force
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 all: build
 
 build:
+	# Permissions workaround for global `npm install`
 	chown -R root:root /root/st2chatops/
 	npm install --production
 	npm cache verify && npm cache clean --force

--- a/testingenv/bionic/docker-entrypoint.sh
+++ b/testingenv/bionic/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  sudo apt-get install -y $ARTIFACT_DIR/*.deb
+  apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/bionic/docker-entrypoint.sh
+++ b/testingenv/bionic/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  apt-get install -y $ARTIFACT_DIR/*.deb
+  sudo apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/bionic/docker-entrypoint.sh
+++ b/testingenv/bionic/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  dpkg -i $ARTIFACT_DIR/*.deb
+  apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/centos6/docker-entrypoint.sh
+++ b/testingenv/centos6/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  rpm -i $ARTIFACT_DIR/*.rpm
+  yum install -y $ARTIFACT_DIR/*.rpm
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/centos7/docker-entrypoint.sh
+++ b/testingenv/centos7/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  rpm -i $ARTIFACT_DIR/*.rpm
+  yum install -y $ARTIFACT_DIR/*.rpm
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/trusty/docker-entrypoint.sh
+++ b/testingenv/trusty/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  sudo apt-get install -y $ARTIFACT_DIR/*.deb
+  apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/trusty/docker-entrypoint.sh
+++ b/testingenv/trusty/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  apt-get install -y $ARTIFACT_DIR/*.deb
+  sudo apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/trusty/docker-entrypoint.sh
+++ b/testingenv/trusty/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  dpkg -i $ARTIFACT_DIR/*.deb
+  apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/xenial/docker-entrypoint.sh
+++ b/testingenv/xenial/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  sudo apt-get install -y $ARTIFACT_DIR/*.deb
+  apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/xenial/docker-entrypoint.sh
+++ b/testingenv/xenial/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  apt-get install -y $ARTIFACT_DIR/*.deb
+  sudo apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env

--- a/testingenv/xenial/docker-entrypoint.sh
+++ b/testingenv/xenial/docker-entrypoint.sh
@@ -6,7 +6,7 @@ case "$operation" in
 pull)
   ;;
 test)
-  dpkg -i $ARTIFACT_DIR/*.deb
+  apt-get install -y $ARTIFACT_DIR/*.deb
   cd /opt/stackstorm/chatops
   sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
   sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env


### PR DESCRIPTION
Some recent nodejs/npm update introduced regression resulting in failed builds due to permissions issue, ex: https://circleci.com/gh/StackStorm/st2chatops/761

* Made a change in Makefile to chown the `/root/st2chatops` to be owned by root:root fixing the breaking `npm --install` perms issues in current builds

Closes #136