### PR TITLE
Bump version in npm-shrinkwrap.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,11 @@ jobs:
     - run:
         name: Get repos and dependencies
         command: |
+          echo "Cloning ${ST2_PACKAGES_BRANCH:-master} branch of st2-packages"
           git clone --branch ${ST2_PACKAGES_BRANCH:-master} --depth 1 ${ST2_PACKAGES_REPO} ~/st2-packages
+          # Use DEPRECATED/all-in-one for now, we'll have to circle back around
+          # and fix this to use the master branch
+          echo "Cloning ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} branch of st2-docker"
           git clone --branch ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
           make -C ~/st2-docker env
           sudo apt-get update -qq && sudo apt-get install -y rpm jq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
     - run:
         name: Get repos and dependencies
         command: |
-          git clone --depth 1 ${ST2_PACKAGES_REPO} ~/st2-packages
-          git clone --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
+          git clone --branch ${ST2_PACKAGES_BRANCH:-master} --depth 1 ${ST2_PACKAGES_REPO} ~/st2-packages
+          git clone --branch ${ST2_DOCKER_BRANCH:-master} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
           make -C ~/st2-docker env
           sudo apt-get update -qq && sudo apt-get install -y rpm jq
           gem install package_cloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
         name: Get repos and dependencies
         command: |
           git clone --branch ${ST2_PACKAGES_BRANCH:-master} --depth 1 ${ST2_PACKAGES_REPO} ~/st2-packages
-          git clone --branch ${ST2_DOCKER_BRANCH:-master} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
+          git clone --branch ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
           make -C ~/st2-docker env
           sudo apt-get update -qq && sudo apt-get install -y rpm jq
           gem install package_cloud

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "st2-hubot",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Forgot to do this in #154, and CircleCI doesn't like the additional changes made in #155, so this tiny PR only bumps the version in `npm-shrinkwrap.json` to match `package.json` from #154.