### PR TITLE
Add ROCKETCHAT_USESSL, remove LISTEN_TO_ALL_PUBLIC

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -148,8 +148,8 @@ export ST2_WEBUI_URL="${ST2_WEBUI_URL:-https://${ST2_HOSTNAME}}"
 # export ROCKETCHAT_PASSWORD=CHANGE-ME-PLEASE
 # export ROCKETCHAT_ROOM=CHANGE-ME-PLEASE
 # Optional:
+# export ROCKETCHAT_USESSL=true
 # export ROCKETCHAT_AUTH=password
-# export LISTEN_ON_ALL_PUBLIC=false
 # export RESPOND_TO_DM=false
 # export RESPOND_TO_EDITED=false
 # export ROOM_ID_CACHE_SIZE=10


### PR DESCRIPTION
In my quest to find a solution to https://github.com/StackStorm/st2chatops/issues/167 I came across a few obstacles. 

In this issue https://github.com/RocketChat/hubot-rocketchat/issues/95 they describe the use of `ROCKETCHAT_USESSL=true` for connecting to a SSL enabled RocketChat instance. 

And in this commit: https://github.com/RocketChat/hubot-rocketchat/commit/6f6e67c9efcf0a37c312fd45cf6ac544ad517054 (Feb 17, 2019) they announced the depreciation of LISTEN_TO_ALL_PUBLIC.