### PR TITLE
lower CircleCI parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     machine: true
     working_directory: ~/StackStorm/st2chatops
-    parallelism: 4
+    parallelism: 2
     shell: /bin/bash --login
     environment:
       DISTROS: bionic focal el7 el8


### PR DESCRIPTION
CircleCI is refusing to run our jobs now giving this error message:
```
Uh oh! When we created this build, your project was configured to use 4x parallelism but you only had 2 containers. If you haven't already, please add more containers or lower your parallelism.
Sorry! Your build didn't run because it needs more containers than your plan allows. Please decrease this project's build parallelism or add more containers to your plan.
```

Apparently they tweaked our plan so that we have 2 concurrent containers instead of 2 concurrent jobs.
Aargh.
