### PR TITLE
Need to set RTM_CLIENT_OPTS for new Hubots in Slack workspaces

### DIFF
--- a/st2chatops.env
+++ b/st2chatops.env
@@ -64,6 +64,8 @@ export ST2_WEBUI_URL="${ST2_WEBUI_URL:-https://${ST2_HOSTNAME}}"
 # export HUBOT_SLACK_TOKEN=xoxb-CHANGE-ME-PLEASE
 # Uncomment the following line to force hubot to exit if disconnected from slack.
 # export HUBOT_SLACK_EXIT_ON_DISCONNECT=1
+# Uncomment line to use rtm connect - needed for new Hubot installs
+# export HUBOT_SLACK_RTM_CLIENT_OPTS='{"useRtmConnect": "true"}'
 
 # Microsoft Teams settings (https://github.com/Microsoft/BotFramework-Hubot)
 # Uses the BotFramework


### PR DESCRIPTION
Update st2chatops.env to include option to force to use rtmConnect

Resolves #172 