### PR TITLE
Fix the CI build: docker-compose and ifconfig changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 # Setup in CircleCI account the following ENV variables:
 # IS_PRODUCTION (default: 0)
-# IS_ENTERPRISE
 # PACKAGECLOUD_ORGANIZATION (default: stackstorm)
 # PACKAGECLOUD_TOKEN
 # SLACK_TOKEN
@@ -29,9 +28,9 @@ jobs:
           echo "Cloning ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} branch of st2-docker"
           git clone --branch ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
           make -C ~/st2-docker env
-          sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs net-tools
+          sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs
           gem install package_cloud
-          sudo pip install "docker-compose==1.27.4"
+          sudo pip install "docker-compose==1.29.2"
           rm -rf node_modules
           # print versions
           docker-compose version
@@ -90,14 +89,6 @@ jobs:
           sleep 10 && echo 'Sleeping for 10 sec ...'
           docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2ctl status
           docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 action-alias list
-          # debug the interfaces
-          echo '-----'
-          ifconfig docker0
-          echo '-----'
-          ifconfig docker0 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p'
-          echo '-----'
-          ifconfig docker0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}'
-          echo '-----'
     - run:
         name: Run tests
         command: |
@@ -158,5 +149,4 @@ workflows:
               only:
                 - master
                 - /v[0-9]+\.[0-9]+/
-                - feature/circleci
-                - circle2.0
+                - debug/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           make -C ~/st2-docker env
           sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs
           gem install package_cloud
-          #sudo pip install "docker-compose==1.14.0"
+          sudo pip install "docker-compose==1.29.2"
           rm -rf node_modules
           # print versions
           docker-compose version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           make -C ~/st2-docker env
           sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs net-tools
           gem install package_cloud
-          sudo pip install "docker-compose==1.25.0"
+          sudo pip install "docker-compose==1.27.4"
           rm -rf node_modules
           # print versions
           docker-compose version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           make -C ~/st2-docker env
           sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs net-tools
           gem install package_cloud
-          sudo pip install "docker-compose==1.14.0"
+          sudo pip install "docker-compose==1.25.0"
           rm -rf node_modules
           # print versions
           docker-compose version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           make -C ~/st2-docker env
           sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs net-tools
           gem install package_cloud
-          sudo pip install "docker-compose==1.29.2"
+          sudo pip install "docker-compose==1.14.0"
           rm -rf node_modules
           # print versions
           docker-compose version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           # sleep 10 is needed to allow the st2-docker test containers time to start up.
           # Otherwise st2api is not ready when the tests run.
           sleep 10 && echo 'Sleeping for 10 sec ...'
-          docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 --version
+          docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2ctl status
           docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 action-alias list
     - run:
         name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,13 +90,21 @@ jobs:
           sleep 10 && echo 'Sleeping for 10 sec ...'
           docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2ctl status
           docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 action-alias list
+          # debug the interfaces
+          echo '-----'
+          ifconfig docker0
+          echo '-----'
+          ifconfig docker0 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p'
+          echo '-----'
+          ifconfig docker0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}'
+          echo '-----'
     - run:
         name: Run tests
         command: |
           source ~/.circlerc
           set -eu
           sleep 10
-          export ST2_HOSTNAME=$(ifconfig docker0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}')
+          export ST2_HOSTNAME=$(ifconfig docker0 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
           docker-compose run \
           -e ST2_HOSTNAME=${ST2_HOSTNAME} \
           -e ST2_USERNAME=${ST2_USER} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,8 @@ jobs:
           docker-compose -f ~/st2-docker/docker-compose.yml up -d
           # sleep 10 is needed to allow the st2-docker test containers time to start up.
           # Otherwise st2api is not ready when the tests run.
-          sleep 10
+          sleep 10 && echo 'Sleeping for 10 sec ...'
+          docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 --version
           docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 action-alias list
     - run:
         name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Cloning ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} branch of st2-docker"
           git clone --branch ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
           make -C ~/st2-docker env
-          sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs
+          sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs net-tools
           gem install package_cloud
           sudo pip install "docker-compose==1.29.2"
           rm -rf node_modules
@@ -87,7 +87,6 @@ jobs:
           # sleep 10 is needed to allow the st2-docker test containers time to start up.
           # Otherwise st2api is not ready when the tests run.
           sleep 10 && echo 'Sleeping for 10 sec ...'
-          docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2ctl status
           docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 action-alias list
     - run:
         name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           echo "Cloning ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} branch of st2-docker"
           git clone --branch ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
           make -C ~/st2-docker env
-          sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs
+          sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs net-tools
           gem install package_cloud
           sudo pip install "docker-compose==1.29.2"
           rm -rf node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
     - run:
         name: Get PackageCloud variables
         command: |
-          set -eu
+          set -e
           distros=($DISTROS)
           DISTRO=${distros[$CIRCLE_NODE_INDEX]}
           PKG_VERSION=$(nodejs -e "console.log(require('./package.json').st2_version);")


### PR DESCRIPTION
This PR is an effort to fix the CI build which started to fail due to upstream changes.

After pinning the `docker-compose`, the current stage has reached the testing step where now hubot fails with:
```
[Mon Sep 19 2022 11:46:16 GMT+0000 (Coordinated Universal Time)] ERROR Failed to authenticate: connect ECONNREFUSED 127.0.0.1:443
[Mon Sep 19 2022 11:46:16 GMT+0000 (Coordinated Universal Time)] ERROR Error: connect ECONNREFUSED 127.0.0.1:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1107:14)

[Mon Sep 19 2022 11:46:16 GMT+0000 (Coordinated Universal Time)] ERROR Error: connect ECONNREFUSED 127.0.0.1:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1107:14)

[Mon Sep 19 2022 11:46:16 GMT+0000 (Coordinated Universal Time)] INFO Hubot will shut down ...
[Mon Sep 19 2022 11:46:16 GMT+0000 (Coordinated Universal Time)] INFO Disconnected from Slack RTM
[Mon Sep 19 2022 11:46:16 GMT+0000 (Coordinated Universal Time)] INFO Exiting...
ERROR: 1
``` 
