### PR TITLE
Update dependencies - 2nd try (security) 

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,6 +4,31 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/polyfill": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.23.4.tgz",
+      "integrity": "sha512-w10wlnER4ZJ60UlxQWiDhaD1nxHrJ3YgGK2V5iws7a07Q1+vQw4eL54kdtuPIadE3LkeG/Xtg+TEI5zWgjYEjw==",
+      "requires": {
+        "core-js": "^2.6.12",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        }
+      }
+    },
     "@danielkalen/source-map-support": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@danielkalen/source-map-support/-/source-map-support-0.4.16.tgz",
@@ -19,33 +44,72 @@
         }
       }
     },
-    "@peculiar/asn1-schema": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-1.1.2.tgz",
-      "integrity": "sha512-ntQ4UnUFgdjs0tfWR6YmEQm/x0glV4OFus/RjxLkaJUKfu/R7VilefBntyUO3MoKWdlCgib30KN+JpCY1HqU2A==",
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "optional": true,
       "requires": {
-        "asn1js": "^2.0.26",
-        "tslib": "^1.11.1"
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "optional": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "optional": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "asn1js": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+          "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+          "requires": {
+            "pvtsutils": "^1.3.2",
+            "pvutils": "^1.1.3",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@peculiar/json-schema": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.10.tgz",
-      "integrity": "sha512-kbpnG9CkF1y6wwGkW7YtSA+yYK4X5uk4rAwsd1hxiaYE3Hkw2EsGlbGh/COkMLyFf+Fe830BoFiMSB3QnC/ItA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "requires": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.0.0"
       }
     },
     "@peculiar/webcrypto": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.0.27.tgz",
-      "integrity": "sha512-sERMakD19gNhwBVXGGoJjBfc28bDbd2YWaio7/x8jKtvwMKNuljM7ANQ6LzEkEvqFAyjf3bhBZktJ6UXy/0Plg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
       "requires": {
-        "@peculiar/asn1-schema": "^1.0.5",
-        "@peculiar/json-schema": "^1.1.10",
-        "pvtsutils": "^1.0.10",
-        "tslib": "^1.11.1",
-        "webcrypto-core": "^1.0.19-next.0"
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
       }
     },
     "@rocket.chat/sdk": {
@@ -85,69 +149,82 @@
         }
       }
     },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "@types/async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.1.tgz",
-      "integrity": "sha1-Q8Oyxg6rQcJcoACcB8p9YZ2UMRk="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.2.tgz",
+      "integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
     },
     "@types/body-parser": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-      "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g="
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
     },
     "@types/clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-bdkCSkyVHsgl3Goe1y16T9k6JuQx7SiDREkq728QjKmTZkGJZuS8R3gGcnGzVuGBP0mssKrzM/GlMOQxtip9cg=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.4.tgz",
+      "integrity": "sha512-vXh6JuuaAha6sqEbJueYdh5zNBPPgG1OYumuz2UvLvriN6ABHDSW8ludREGWJb1MLIzbwZn4q4zUbUCerJTJfA=="
     },
     "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
-      "integrity": "sha1-11a9GoXDTYfq9EyIi60nuopLfPA=",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.2.tgz",
-      "integrity": "sha1-XuiiLmAgBb5nZ99rLLqYed8/dao=",
+      "version": "4.17.41",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
+      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
       "requires": {
         "@types/node": "*",
-        "@types/range-parser": "*"
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "@types/form-data": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
+      "integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
       "requires": {
-        "@types/node": "*"
+        "form-data": "*"
       }
+    },
+    "@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "@types/jsonwebtoken": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
-      "integrity": "sha1-jRmdq03bW7oyNPgxG4BNICevKzo=",
+      "integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
       "requires": {
         "@types/node": "*"
       }
@@ -158,199 +235,194 @@
       "integrity": "sha1-sth6Xj341LGMpCbFEFzXAcIwbUA="
     },
     "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
       "version": "9.6.36",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.36.tgz",
       "integrity": "sha1-xKK9sW06ebNOAUZLS9OMG4Se/aw="
     },
-    "@types/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+    "@types/qs": {
+      "version": "6.9.10",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+    },
+    "@types/request": {
+      "version": "2.48.12",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
+      "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
       "requires": {
+        "@types/caseless": "*",
         "@types/node": "*",
-        "form-data": "^4.0.0"
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
       },
       "dependencies": {
-        "combined-stream": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
         "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
           "requires": {
             "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
+            "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
         }
       }
     },
-    "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
-    },
-    "@types/request": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
-      "integrity": "sha1-5ALWkapmcPu/8ZV7FfEnAjCrQvo=",
+    "@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
       "requires": {
-        "@types/caseless": "*",
-        "@types/form-data": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*"
+        "@types/mime": "^1",
+        "@types/node": "*"
       }
     },
     "@types/serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha1-pPy4THNE859w3E7sDh5/EKSFl6M="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.4.tgz",
+      "integrity": "sha512-aWK1reDYWxcjgcIIPmQi3u+OQDuYa9b+lr6eIsGWrekJ9vr1NSjr4Eab8oQ1iKuH1ltFHpXGyerAv1a3FMKxzQ=="
     },
     "@types/tough-cookie": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha1-naRO11VxmZtlw3tgybK4jbVMWF0="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
     "@types/url-join": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.3.tgz",
-      "integrity": "sha1-E19AoBFA7TO1IoNume0g38EFYTc="
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.6.tgz",
+      "integrity": "sha512-7ynfYbbQHV3iz7K77wzgVoBBisyoMuFhLSoIhs1dl49WPzMZ0ybVqUq6Opa6n+0vBaWDXmzNbBkeNzsmPFWDJA=="
+    },
+    "@unimodules/core": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@unimodules/core/-/core-7.1.2.tgz",
+      "integrity": "sha512-lY+e2TAFuebD3vshHMIRqru3X4+k7Xkba4Wa7QsDBd+ex4c4N2dHAO61E2SrGD9+TRBD8w/o7mzK6ljbqRnbyg==",
+      "optional": true,
+      "requires": {
+        "compare-versions": "^3.4.0"
+      }
+    },
+    "@unimodules/react-native-adapter": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@unimodules/react-native-adapter/-/react-native-adapter-6.3.9.tgz",
+      "integrity": "sha512-i9/9Si4AQ8awls+YGAKkByFbeAsOPgUNeLoYeh2SQ3ddjxJ5ZJDtq/I74clDnpDcn8zS9pYlcDJ9fgVJa39Glw==",
+      "optional": true,
+      "requires": {
+        "expo-modules-autolinking": "^0.0.3",
+        "invariant": "^2.2.4"
+      }
     },
     "@webex/common": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.80.178.tgz",
-      "integrity": "sha512-UMZSSUxomcvnFvOt3/IiNMBDLGeLMPR62u/9ZJ6R0qUPsIIJpO9yBI+6N04fJS4hvTBinDMeD66ql42hATRmiQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.161.0.tgz",
+      "integrity": "sha512-gY0IK2yeNv10b6AYrXa5FAicDvYd91jkY4Mf/L1UosuOLHA8UEVRNIQxMDPSdoaHUXBk+WI6rti1d/XnQFz8QQ==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
         "backoff": "^2.5.0",
+        "bowser": "^2.11.0",
         "core-decorators": "^0.20.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "safe-buffer": "^5.2.0",
         "urlsafe-base64": "^1.0.0"
       },
       "dependencies": {
-        "backoff": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-          "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-          "requires": {
-            "precond": "0.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "precond": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-          "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "@webex/common-timers": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.80.178.tgz",
-      "integrity": "sha512-BJUWfDtqareL6HJbLjTk2dmiuGqwtDGHQF50YFKkz6ck2ZapmJZSsox3q3tsImLavYfrF0ltQYnRCLOx0q4mww==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.161.0.tgz",
+      "integrity": "sha512-30oeHYvnhfP79KRw5+tDbzOkqXslPy4xjcQMYDWTsg/xvUeSaX9Wf7Odumnkspee4SNuqcqYTCKP7Pc8ZCSVHg==",
       "requires": {
+        "@babel/runtime-corejs2": "^7.14.8",
         "envify": "^4.1.0"
       }
     },
     "@webex/helper-html": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.80.178.tgz",
-      "integrity": "sha512-08pTVqvvNvXRsqvtSHz34At8Y6eMBGs5P1byvYdl6CE80LIfng69+cNFPzQTLKvRFmP+o3GZc9Uj8Yc1GINaWQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.161.0.tgz",
+      "integrity": "sha512-kQ7UX2X4Oo5R3W42ATIHr/Mb/VpJO+FNRtHQaPFs5vmLUT4Zy4hJ7AHn1Mo7FkOIn40eAe5ezSs/x+ifsal/aw==",
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/helper-image": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.80.178.tgz",
-      "integrity": "sha512-LwnqJCP7/yank0dVM5qiq9K1ALFPgHl68Z9AfObNSorNC8PljdcG/hsowNkM9rj/s0rv9+eB53hbL0g68FIzJA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.161.0.tgz",
+      "integrity": "sha512-KdkVqS7D0hoDKCTFDcVMmDy7UhAEynitTkXlwHYJFigiq5Lq0R/YHdk7DiziHMABMxfrq6vl9mhUakzXjhQCAg==",
       "requires": {
-        "@webex/http-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/http-core": "1.161.0",
         "envify": "^4.1.0",
-        "exif": "^0.6.0",
+        "exifr": "^5.0.3",
         "gm": "^1.23.1",
-        "lodash": "^4.17.15",
-        "mime-types": "^2.1.24"
+        "lodash": "^4.17.21",
+        "mime": "^2.4.4",
+        "safe-buffer": "^5.2.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
         },
-        "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
-        },
-        "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-          "requires": {
-            "mime-db": "1.43.0"
-          }
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "@webex/http-core": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.80.178.tgz",
-      "integrity": "sha512-iBaHvEaX9KdMaB4mUM+dpyM56qWOplI4GFDVAxYmf8SLZMiiQwjCC6gu/TLMTBcg4vPiQwO/9tHVPCkk//vNFA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.161.0.tgz",
+      "integrity": "sha512-2JCvZ1lJwwv2Ajn9cn7QrbD6QbMR1p9pXu2JcjhYP2WdHssT6pBvNMZ009uJ1JRGexY3QQKuBNlzn8M87xbQtw==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
         "envify": "^4.1.0",
-        "file-type": "^3.9.0",
+        "file-type": "^16.0.1",
         "global": "^4.4.0",
         "is-function": "^1.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "parse-headers": "^2.0.2",
         "qs": "^6.7.0",
         "request": "^2.88.0",
+        "safe-buffer": "^5.2.0",
         "xtend": "^4.0.2"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -358,205 +430,46 @@
             "uri-js": "^4.2.2"
           }
         },
-        "asn1": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
         "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "extend": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-        },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
           }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
           "requires": {
-            "mime-db": "1.43.0"
+            "mime-db": "1.52.0"
           }
         },
         "oauth-sign": {
@@ -564,20 +477,10 @@
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
-        "psl": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-          "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-        },
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "qs": {
           "version": "6.11.2",
@@ -615,9 +518,9 @@
           },
           "dependencies": {
             "qs": {
-              "version": "6.5.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+              "version": "6.5.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+              "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
             }
           }
         },
@@ -625,27 +528,6 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "sshpk": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-          "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
         },
         "tough-cookie": {
           "version": "2.5.0",
@@ -656,41 +538,10 @@
             "punycode": "^2.1.1"
           }
         },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
-        "uri-js": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
-          }
         },
         "xtend": {
           "version": "4.0.2",
@@ -700,51 +551,39 @@
       }
     },
     "@webex/internal-plugin-calendar": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.80.178.tgz",
-      "integrity": "sha512-kl4MUC5crbKPEAbQKa6ELc/26CkQXQMBOlHcUKgvBNXkUl7YlM6ezWfBRnZr1AAYNGMW9Ezzd+TvL1iojg5n2Q==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.161.0.tgz",
+      "integrity": "sha512-tbw50C4rW6MAWpu8rD1wQyivmDjR6lA6dSYwddy2jNNvmmq0lOkR0CQjry2KTxbzpFQzptXEMmpXbMZFCRCLKw==",
       "requires": {
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-encryption": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-encryption": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "btoa": "^1.2.1",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/internal-plugin-conversation": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.80.178.tgz",
-      "integrity": "sha512-yB+3KCHMAi0YN/sDbaN0NeC/NzNe8Em5AaLID+9CqGE5G/94QTW4O2YssyqJJ2CvDhLlhXS5B0HsqbJGAKgQMA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.161.0.tgz",
+      "integrity": "sha512-1/yud5FtF7QXHJn+NspdDaBF5ecQmnoafX+8LiZhnOSO8/eCuWPkBqzxTc7hvnI0+oluontZHKR2ZN6wrREn1Q==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/helper-html": "1.80.178",
-        "@webex/helper-image": "1.80.178",
-        "@webex/internal-plugin-encryption": "1.80.178",
-        "@webex/internal-plugin-user": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
-        "crypto-js": "^3.1.9-1",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/helper-html": "1.161.0",
+        "@webex/helper-image": "1.161.0",
+        "@webex/internal-plugin-encryption": "1.161.0",
+        "@webex/internal-plugin-user": "1.161.0",
+        "@webex/webex-core": "1.161.0",
+        "crypto-js": "^4.1.1",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
-        "node-scr": "^0.2.2",
+        "lodash": "^4.17.21",
+        "node-scr": "^0.3.0",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -753,49 +592,44 @@
       }
     },
     "@webex/internal-plugin-device": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-1.80.178.tgz",
-      "integrity": "sha512-1QJ+cy2OKOzKpFMEj0Qq51/e2vWFhpoqxpcClGZ+D3tt5H/xHa1GHtgdWXSalfF/PKJl6TSnR0sgD/p3MoQcBQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-1.161.0.tgz",
+      "integrity": "sha512-y8MV6gmHdC/5WijCPrTXNmQGRSqt4WADNT4CzdyYBtAkybOHRJRineE2IqhH72MRYkh/+aDBjW2mvbGhMUkwWg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/http-core": "1.80.178",
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/http-core": "1.161.0",
+        "@webex/internal-plugin-metrics": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "ampersand-collection": "^2.0.2",
         "ampersand-state": "^5.0.3",
-        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/internal-plugin-encryption": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.80.178.tgz",
-      "integrity": "sha512-R2AJh/cA/g3vIgYmbkqOxE/Z/Trj1cl640Ldshj7wwT7cX/KTmLD3dChP4uyV0X316v5EofZRwLyMSi4qX/Ysw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.161.0.tgz",
+      "integrity": "sha512-Fgq4UyHLmKhfwWQBBLhK+Krz0UIB/cu3nwPnNr2EvUb7ZeoxPcd+jnMEHp+QDEUMa41Vr59pYPPBxvhtv1CLqg==",
       "requires": {
-        "@peculiar/webcrypto": "^1.0.22",
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/http-core": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/http-core": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "asn1js": "^2.0.26",
-        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
-        "node-jose": "^0.11.1",
-        "node-kms": "^0.3.2",
-        "node-scr": "^0.2.2",
+        "isomorphic-webcrypto": "^2.3.8",
+        "lodash": "^4.17.21",
+        "node-jose": "^2.0.0",
+        "node-kms": "^0.4.0",
+        "node-scr": "^0.3.0",
         "pkijs": "^2.1.84",
+        "safe-buffer": "^5.2.0",
         "valid-url": "^1.0.9"
       },
       "dependencies": {
@@ -807,202 +641,162 @@
             "ms": "^2.1.1"
           }
         },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "@webex/internal-plugin-feature": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.80.178.tgz",
-      "integrity": "sha512-2UJgZu8F5x0MaLSS5StOLOIEpirYy80uqCRxyTvuqk/6/bJe9dw01kCXZtVT1xC0bya4Z2bjzhzqGkcDaOMF+A==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.161.0.tgz",
+      "integrity": "sha512-sKuICbBHWx7Fi60EsdLe0H4preh8XT+I464TJ01bE2EDEldEbl1viFrAE1TOAlkXokWb2+xKEH4c/9hFQqB4VA==",
       "requires": {
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/internal-plugin-lyra": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.80.178.tgz",
-      "integrity": "sha512-023/09xkyc6O8PV3L49dWnxt5HDO5yW4RFhc5zpNwZI6MG+Jpuj9PXgJ6uZ4NJbIMD4T59zcNioPE5f9lj82/A==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.161.0.tgz",
+      "integrity": "sha512-B50bsDVdvJBNP56j0RbLxlbByIr/CRpRzBTKfGzV6zQoXUYs99inLTCkMc3Q4NwRCISaeBzcO5wFadJG8H62Xg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-encryption": "1.80.178",
-        "@webex/internal-plugin-feature": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-encryption": "1.161.0",
+        "@webex/internal-plugin-feature": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-mercury": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.80.178.tgz",
-      "integrity": "sha512-oKlOIwqTMkkC4C9q6fQ1XTSbL0a0IvO0lrMvr/jF4gLWrg5EszXjuvft+qWB4N5z3hmHGvubrQyUNuqvBhWvaw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.161.0.tgz",
+      "integrity": "sha512-wm9STxbSDNj/1iW198LWk7F5M5AgUI1+yonSSUDOvc8QmxRuk7fuk1fZ0VrqNAR7uEkO56gEmnG+91pJTt71eA==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-feature": "1.80.178",
-        "@webex/internal-plugin-metrics": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-feature": "1.161.0",
+        "@webex/internal-plugin-metrics": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "backoff": "^2.5.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "uuid": "^3.3.2",
-        "ws": "^4.1.0"
+        "ws": "^8.2.2"
       },
       "dependencies": {
-        "async-limiter": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-          "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-        },
-        "backoff": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-          "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-          "requires": {
-            "precond": "0.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "precond": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-          "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "ws": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0"
-          }
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
         }
       }
     },
     "@webex/internal-plugin-metrics": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.80.178.tgz",
-      "integrity": "sha512-gibR0AT/yvmWufCyBZA74THzDez80WTbO28jW+JKidlpcjf6+Gx6SrgQ+nl60I3zHf7v9TVOsHWMsytRQRWNmQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.161.0.tgz",
+      "integrity": "sha512-B/OJhvZlUNBRhPck1IIxJRAg7eTTtry6+/K+wmjLwtfH1FF9HgSOFu0i7cQiyfql/rzLrs4QaG/6PpqiGl+cuQ==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-presence": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.80.178.tgz",
-      "integrity": "sha512-/nJ72ttqLkdBOv8Z7wN1yWIPLyaPtJu3GDoshHwXEtvF51WzR5CHt51VhgmOu0g6spejBcYMJ5eNppozrnQqCQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.161.0.tgz",
+      "integrity": "sha512-ch8ojz267xyNlOjywHRTg0rKbBGyNZ4CkSTq1N0TaJ2ne0ZM9mZA+mTC2cQ/p4Fi3jQA3iE5FOQZERvxsY5ABw==",
       "requires": {
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/internal-plugin-search": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.80.178.tgz",
-      "integrity": "sha512-zWojY1Iz2tF3yN9py5tg5d9dkyV8MetMMB01Mp5sCLGjInCEBhwbSMcHTOu2tigzr8pd61Y5EP5pvD7VOWP5Kg==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.161.0.tgz",
+      "integrity": "sha512-9wWIPVNrvsOQ8WOjFsOqzT4s5PDvmJz+L+ZKREsyqLsH7RfO92dsjUnIKYhpYQj7TGaByVlmdOzLf//IjJ4N7Q==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-encryption": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-encryption": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
+      }
+    },
+    "@webex/internal-plugin-support": {
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-support/-/internal-plugin-support-1.161.0.tgz",
+      "integrity": "sha512-ye7XQHXApxGnnbMkPRbN1QA2fFFIISvccsn20PJszdVX4GRohGSBhjQxfZlZSK2MaCrGsFR3FhB4/kspURXw6g==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.21",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
     "@webex/internal-plugin-user": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.80.178.tgz",
-      "integrity": "sha512-KXKvxi34IsRXTBj6KTboSVVhLVe6yb43Ht2HPrGp1Yu8Qx8eptnBbKGEZpAJX1KoQEreQxbRnl6t8GnwRdo3Jw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.161.0.tgz",
+      "integrity": "sha512-4NHMIi1+0trR5TjhduX5QTQ+8acNhlSJ64XE4nwxRIer0hADAlQXBLPA1IFf72PYG8l2WijQ0vy8tv07Wra50A==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/plugin-attachment-actions": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.80.178.tgz",
-      "integrity": "sha512-jW/bq/TRbYaTQrZJdri1CWxIk+CCBgtsdj8Uf2utuBz9aT6jEto2jTZOo7w0G8IeIjCqk+yGoVWBGcCBHuc7Xw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.161.0.tgz",
+      "integrity": "sha512-TBtdHUrkv2i6+ABrLvKZv9VLDEGb/LoJ04xTygMMqKgTrRrsmoS62bj1a2AFYaxKbpQdGPTsuV7/6H4wB5Ikzg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -1012,11 +806,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.3",
@@ -1026,34 +815,30 @@
       }
     },
     "@webex/plugin-authorization": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.80.178.tgz",
-      "integrity": "sha512-iVSAlJinBVGA48ZUKJW5lG0NSFgvfZwavFe4mD+BKF05NdvTlp9aXRe90evkOWT3VV97rc4PNqd8iqJelaWCPg==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.161.0.tgz",
+      "integrity": "sha512-0ZQfYd7Pdr846Guh1BYcSQJtS0woUQVvNebRXGhwr+YZPC4oYLMk5ISrY+1oocXrZbdJdfkka4ij53lhazYA/Q==",
       "requires": {
-        "@webex/plugin-authorization-browser": "1.80.178",
-        "@webex/plugin-authorization-node": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/plugin-authorization-browser": "1.161.0",
+        "@webex/plugin-authorization-node": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-authorization-browser": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.80.178.tgz",
-      "integrity": "sha512-Z9J+MAQ+29eGEINL1hZv4PwxkyxW3AccAsHxvCmO/h8y/3Cu0x8jQ3xIos7vmmLU5dtqIv0XDktnDmd30/xeNw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.161.0.tgz",
+      "integrity": "sha512-MSipQ/IQ8fWTu3sDWmQoxN0yGXBwwG3cPt9M+tE4QMmzkF+PjBSGTCmIzLy147U24h5d9wQGGJBWSn8tQwbM1Q==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -1062,37 +847,32 @@
       }
     },
     "@webex/plugin-authorization-node": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.80.178.tgz",
-      "integrity": "sha512-8mAsOKfiPfYSXiAIroxE/GspZMtw0jcm6Rk+ENJhWrXSgQf5XgPrRR/y3uIpZ7PNeboUNObRKkx5vjkwHgbMBQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.161.0.tgz",
+      "integrity": "sha512-oYYHjEv/cVt+ZAbos1En4zA7+GtsxabwR0ZnjaHctSSxfpHoemzO68LJXvqJQRIbVl9do6GNizic4PN5KabhfQ==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-device-manager": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.80.178.tgz",
-      "integrity": "sha512-AiXCrLl7r2EsJ+SrZYpJKU4MDECVQoSCHR8nJ8V5yGtklKntiHFpj5P6BFOhI6+l6kU3zaCEOhbtQJ0QS37KaA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.161.0.tgz",
+      "integrity": "sha512-xzIHP0llGJojMeuoMEtgnDPYpbj/HDMprGVMV/AGyCAuOEdY6mORNgbdavXX/YFVPJL6awBb7G6NXd77Aowujg==",
       "requires": {
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-lyra": "1.80.178",
-        "@webex/internal-plugin-search": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-lyra": "1.161.0",
+        "@webex/internal-plugin-search": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -1101,48 +881,63 @@
       }
     },
     "@webex/plugin-logger": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.80.178.tgz",
-      "integrity": "sha512-maEaqtjemF+G5fI3/+E4YkpBqPhXIdGXRE4kXaqj1uRG4wiksopYOAroQ0ILtsAo3yOvqXu6KIiwnRZ37Da8cA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.161.0.tgz",
+      "integrity": "sha512-+JHz2Qgm7pHq2Syfv457N0rQPiSivVFqiq3V+KQ1iAUJiDbz3DlUTIGR90njtrcGDdNwHqqwbZonJ6KZUcOotQ==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/plugin-meetings": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.80.178.tgz",
-      "integrity": "sha512-aYKtPkMNPqRDuViCsMtLo3mnoZGxvQiogF1ctB6cckatihQnta/Du8xkcr0fLMyBhwhFcX2F7mx0zCWnUZNpFg==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.161.0.tgz",
+      "integrity": "sha512-nAYh5ZWX+vGDoxLvUHL8/YdT29VsbHZGw/U2q216KDuvxwhDNWGOnHFp32Eudi1cX79phZSOPgjzwtJ4Xq9oYg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
-        "bowser": "1.9.4",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
+        "bowser": "^2.11.0",
         "btoa": "^1.2.1",
         "envify": "^4.1.0",
         "global": "^4.4.0",
+        "ip-anonymize": "^0.1.0",
         "javascript-state-machine": "^3.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
+        "readable-stream": "^3.6.0",
         "sdp-transform": "^2.12.0",
-        "uuid": "^3.3.2"
+        "uuid": "^3.3.2",
+        "webrtc-adapter": "^7.7.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
         },
         "uuid": {
           "version": "3.4.0",
@@ -1152,18 +947,18 @@
       }
     },
     "@webex/plugin-memberships": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.80.178.tgz",
-      "integrity": "sha512-10YCfIuyj89GkBm2EClOafmedQVk9OkDNP5JLnaSDhgzbj/32geFkTApXMrKKaVr7EQLofpvZNtIPKFY+cuCfw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.161.0.tgz",
+      "integrity": "sha512-pjs7QAKu8E8QN3niULoZqQXkjfrD+Hqxe3S68ZstBPFvLIhmngP6SRPVQ0bKQIY1V25jGQ1fLigfjOnYjgBgMg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -1173,11 +968,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.3",
@@ -1187,64 +977,43 @@
       }
     },
     "@webex/plugin-messages": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.80.178.tgz",
-      "integrity": "sha512-OUOwR4u51p+Y2sGdIHLSIS33tNJFcUbkZJhT6Rnlu6xevJjwRALcUYJpVvkALNpiLos/j3OOfEc5hk7xCOJoOA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.161.0.tgz",
+      "integrity": "sha512-vDTdYK0zulpK9J1+ucK3ZB+hGCA3lo0hKIscR0ScN33ideaiEDEFFBRqckmdeRammnyHHZ8Avi/kVYxfBbhtZg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
-        "debug": "^3.2.6",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/plugin-people": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.80.178.tgz",
-      "integrity": "sha512-bOaxiawzoPUdCrvFaxI9X+NlakOeXR2wv7rereBO2+QGU4tt7TheURhHGWCDggtcwYIqGJv2XipNdJhI4w0dTA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.161.0.tgz",
+      "integrity": "sha512-G6LbPPqgTht0pkorIJLpkChEnAo+R7u9q51KoPOLj1kM9LOqzOT6JA55z/WfzBZRwYITbfL7qV58FhyQ15sOgA==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-rooms": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.80.178.tgz",
-      "integrity": "sha512-ttBOJcil8zJwisK+vAHupFDAtbDT/7BeLIDTaV3YVXn/iHk8jKTPyxu2HDCXlhQvApV8F9sBDrOxigEthqBCEw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.161.0.tgz",
+      "integrity": "sha512-9amxryhzajJyyDFpLGa+YCBI4yvPoTgIj30dQZO0TniCbOYw/QM3BRzvtcn8+195V/ePQeR0RYcd9vqwtWy2iw==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -1254,11 +1023,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.3",
@@ -1268,68 +1032,66 @@
       }
     },
     "@webex/plugin-team-memberships": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.80.178.tgz",
-      "integrity": "sha512-GsQutBpXmLd4yNdnqJPQYTtmoQaumVhdtk3QJ5P0XHH0NWOATvfr9DFg5H3zDsAGW15Bc3TJ8qXDQ7VaYJ1lLw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.161.0.tgz",
+      "integrity": "sha512-LIrp/hpd4RSl0gh97xl7xtopz0PSbeoUatO8u4XkBjUAZ6iPjYAyRuu68yXG7QxfCacePF+jdrdnOuhWsBMIVw==",
       "requires": {
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-teams": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.80.178.tgz",
-      "integrity": "sha512-Lo32lfa0549TkFeLXlfEDNd4N9k7DspxwEMpQUJzcKgmmuMI9uIQMlRt3uI2fAkQHL+D2AtK2pxsbY2iH2yzWQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.161.0.tgz",
+      "integrity": "sha512-IrZf33pY6FTStoBumxTSAAXSmzQ7Izia6ICPBi79J2MWrt81lm4MQP5OP+eg2Ub2U6kwrflIfTfYPNjG+OVJNQ==",
       "requires": {
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-webhooks": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.80.178.tgz",
-      "integrity": "sha512-2yPnjMOLHZRUWjxS8uRZQR8Yh8sjqqF+tb/XmXTYwqd7RtLvuGOB1AmWzyUuv0IM2HGQBnViJB4sF84zLZKvZA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.161.0.tgz",
+      "integrity": "sha512-KA3rUC9ukfxyEiXwJdeZDxk+HDRtwkn5aE5ZAole7HxhidcY7Obvi+NJuSVSvp+W6giC0McFivoLP6UMwnPEww==",
       "requires": {
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/storage-adapter-local-storage": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.80.178.tgz",
-      "integrity": "sha512-wLrhqchxXSL7O0iq8x7HA51H2RCHlRnPptpj+OV0DZt0mrx7phSO2FT2fY7ySyjUkN+QescJAb9QU37pFbn8ug==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.161.0.tgz",
+      "integrity": "sha512-Dzh/PQUbGeQ4h7Aq67QlS0uPZM/zldu8GZo8xjpZSGWDQx+t4ygcSXNgbVXLl9FrItZsxNAxBG2WTkNA5dBzIQ==",
       "requires": {
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/webex-core": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.80.178.tgz",
-      "integrity": "sha512-K8wVB4DCbbCfMz2mH5LG9farSS1LU8dV9vFyoGBSHt/N/Ori502QFmP+dA0lVg1zay3eQt/GHO3XNCI+Q+lnkw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.161.0.tgz",
+      "integrity": "sha512-vmHdkZMXE+iUso1knXYnREOvm6NyUwLnSao+47xcqIvTKh+zOxl0VbvP+ovVLYux9xnqIyr6IQERDhJjKgml8w==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/http-core": "1.80.178",
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/http-core": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "ampersand-collection": "^2.0.2",
         "ampersand-events": "^2.0.2",
         "ampersand-state": "^5.0.3",
-        "babel-runtime": "^6.26.0",
         "core-decorators": "^0.20.0",
-        "crypto-js": "^3.1.9-1",
+        "crypto-js": "^4.1.1",
         "envify": "^4.1.0",
         "jsonwebtoken": "^8.5.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -1337,15 +1099,10 @@
         }
       }
     },
-    "@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
-    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+      "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q=="
     },
     "accepts": {
       "version": "1.3.8",
@@ -1371,35 +1128,10 @@
         }
       }
     },
-    "adal-node": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.4.tgz",
-      "integrity": "sha512-zIcvbwQFKMUtKxxj8YMHeTT1o/TPXfVNsTXVgXD8sxwV6h4AFQgK77dRciGhuEF9/Sdm3UQPJVPc/6XxrccSeA==",
-      "requires": {
-        "@xmldom/xmldom": "^0.8.3",
-        "async": "^2.6.3",
-        "axios": "^0.21.1",
-        "date-utils": "*",
-        "jws": "3.x.x",
-        "underscore": ">= 1.3.1",
-        "uuid": "^3.1.0",
-        "xpath.js": "~1.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        }
-      }
-    },
     "adaptivecards": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.5.tgz",
-      "integrity": "sha512-Rj+QK0qtBOfLGy3ClXylKxL4ze/a6mtPiJL7Ctjyc1Uso9O1x/LAAu49F36ZQbgAa8vWkKW91RKcwBBOxk3HDg=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.6.tgz",
+      "integrity": "sha512-/l34rvdRzQ20QdGLk+awRUotexu3N4Ih3O0qR8cM+2wWe0pggvWhmFdwVFmM+YgIS5pWtl2u7XAJynUaFIQAIw=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -1423,13 +1155,13 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "optional": true
     },
     "ampersand-class-extend": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-2.0.0.tgz",
-      "integrity": "sha1-Uolf+lkhdjSmGI/RhLEEj12Aiv8=",
+      "integrity": "sha512-i8hQvA4vZz9UfQAi0A4oBASYOZzlYgjFVkw0K1xpeKNSvq+KYkFOqJKkNvHCbbuKUNJnFk3kECSKPDAJ6ocEOg==",
       "requires": {
         "lodash": "^4.11.1"
       }
@@ -1448,7 +1180,7 @@
     "ampersand-events": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
-      "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
+      "integrity": "sha512-pPnVEJviRxXi9YhZA9j3GwGGBTlDLi+YIoBvrpKXgce+CO1nMlZU2aOV8OJogNuR2YPbptAUHNz7SKX+MvLj8A==",
       "requires": {
         "ampersand-version": "^1.0.2",
         "lodash": "^4.6.1"
@@ -1469,7 +1201,7 @@
     "ampersand-version": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ampersand-version/-/ampersand-version-1.0.2.tgz",
-      "integrity": "sha1-/489TOrE0yzNg/a9Zpc5f3tZ4sA=",
+      "integrity": "sha512-FVVLY7Pghtgc8pQl0rF3A3+OS/CZ+/ILLMIYIaO1cA9v5SRkainqUMfSot3fu32svuThIsYK3q9iCsH9W5+mWQ==",
       "requires": {
         "find-root": "^0.1.1",
         "through2": "^0.6.3"
@@ -1488,9 +1220,16 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+        }
       }
     },
     "array-flatten": {
@@ -1501,22 +1240,27 @@
     "array-next": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-next/-/array-next-0.0.1.tgz",
-      "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
+      "integrity": "sha512-sBOC/Iaz2hCcYi2XlyRfyZCRUxamlE5NJXEFjE9BTx23HALnWAFsPjGtfrAclt9o3G/38Het2yyeyOd3CEY7lg=="
     },
     "array-parallel": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
-      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
+      "integrity": "sha512-TDPTwSWW5E4oiFiKmz6RGJ/a80Y91GuLgUYuLd49+XBS75tYo8PNgaT2K/OxuQYqkoI852MDGBorg9OcUSTQ8w=="
     },
     "array-series": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
-      "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8="
+      "integrity": "sha512-L0XlBwfx9QetHOsbLDrE/vh2t018w9462HM3iaFfxRiK83aJjAt/Ja3NMkOW7FICwWTlQBa3ZbL5FKhuQWkDrg=="
     },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "asmcrypto.js": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-0.22.0.tgz",
+      "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
     },
     "asn1": {
       "version": "0.2.3",
@@ -1524,15 +1268,11 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1js": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
-      "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
-      "dependencies": {
-        "pvutils": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-          "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
-        }
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
+      "integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
+      "requires": {
+        "pvutils": "^1.1.3"
       }
     },
     "assert-plus": {
@@ -1559,6 +1299,12 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "optional": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1577,51 +1323,49 @@
         "follow-redirects": "^1.14.0"
       }
     },
-    "b64u": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/b64u/-/b64u-2.0.0.tgz",
-      "integrity": "sha512-N3SnhKhQtwm9a4+rdNT0JvnNdPlRwpQZN4tfJwOE3/qJVzM+OlYj/Iz2n1S3KXAQmKHaRwWUNW5gEnjuD8cXHg=="
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+    "b64-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
+      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
+        "base-64": "^0.1.0"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+    "b64u-lite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/b64u-lite/-/b64u-lite-1.1.0.tgz",
+      "integrity": "sha512-929qWGDVCRph7gQVTC6koHqQIpF4vtVaSbwLltFQo44B1bYUquALswZdBKFfrJCPEnsCOvWkJsPdQYZ/Ukhw8A==",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "b64-lite": "^1.4.0"
       }
     },
     "backoff": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
-      "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
+      "requires": {
+        "precond": "0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha1-Y5nVcuK8P5CpqLItXbsKMtM/eI0="
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -1736,11 +1480,12 @@
       }
     },
     "botbuilder": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.16.0.tgz",
-      "integrity": "sha1-cA6jkYksYm+h+SJojSx0KwaE9QM=",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.30.0.tgz",
+      "integrity": "sha512-TpqYa75IvU+aa4VXS0ZL0LFGGjDnw/O04XnAc1VzQw+S82s0vA7YHLAKW9LaKkz4f3cdQKskU48+tZsx+D3wzg==",
       "requires": {
         "@types/async": "^2.0.48",
+        "@types/clone-deep": "^4.0.1",
         "@types/express": "^4.11.1",
         "@types/form-data": "^2.2.1",
         "@types/jsonwebtoken": "^7.2.6",
@@ -1751,6 +1496,7 @@
         "async": "^1.5.2",
         "base64url": "^3.0.0",
         "chrono-node": "^1.1.3",
+        "clone-deep": "^4.0.1",
         "jsonwebtoken": "^8.2.2",
         "promise": "^7.1.1",
         "request": "^2.88.0",
@@ -1759,129 +1505,59 @@
         "url-join": "^1.1.0"
       },
       "dependencies": {
+        "@types/node-fetch": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+          "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+          "requires": {
+            "@types/node": "*",
+            "form-data": "^4.0.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "20.9.4",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.4.tgz",
+              "integrity": "sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==",
+              "requires": {
+                "undici-types": "~5.26.4"
+              }
+            }
+          }
+        },
+        "@xmldom/xmldom": {
+          "version": "0.8.10",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+          "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
+        },
+        "adal-node": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.4.tgz",
+          "integrity": "sha512-zIcvbwQFKMUtKxxj8YMHeTT1o/TPXfVNsTXVgXD8sxwV6h4AFQgK77dRciGhuEF9/Sdm3UQPJVPc/6XxrccSeA==",
+          "requires": {
+            "@xmldom/xmldom": "^0.8.3",
+            "async": "^2.6.3",
+            "axios": "^0.21.1",
+            "date-utils": "*",
+            "jws": "3.x.x",
+            "underscore": ">= 1.3.1",
+            "uuid": "^3.1.0",
+            "xpath.js": "~1.1.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.4",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+              "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+              "requires": {
+                "lodash": "^4.17.14"
+              }
+            }
+          }
+        },
         "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "aws4": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-          "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
-          "requires": {
-            "ajv": "^6.5.5",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
-        },
-        "mime-db": {
-          "version": "1.38.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-          "integrity": "sha1-GiqrFtqesWe0nG5N8tnGjWPY4q0="
-        },
-        "mime-types": {
-          "version": "2.1.22",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-          "integrity": "sha1-/ms1WhkJJqt2mMmgVWoRGZshmb0=",
-          "requires": {
-            "mime-db": "~1.38.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        },
-        "url-join": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
-        }
-      }
-    },
-    "botbuilder-teams": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/botbuilder-teams/-/botbuilder-teams-0.2.9.tgz",
-      "integrity": "sha512-aLb3pdGAZaBPBZaVcjxSnzuQPIiL4AIFIxmLl4pJBdve+FXZesS7ZOCMrotsAea9bj0HoYffqpYaFAT4UHQbuA==",
-      "requires": {
-        "adaptivecards": "^1.0.0",
-        "botbuilder": "^3.30.0",
-        "crypto": "^1.0.1",
-        "ms-rest": "^2.5.0",
-        "sprintf-js": "^1.1.1",
-        "tsc": "^1.20150623.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1889,210 +1565,106 @@
             "uri-js": "^4.2.2"
           }
         },
-        "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-        },
-        "botbuilder": {
-          "version": "3.30.0",
-          "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.30.0.tgz",
-          "integrity": "sha512-TpqYa75IvU+aa4VXS0ZL0LFGGjDnw/O04XnAc1VzQw+S82s0vA7YHLAKW9LaKkz4f3cdQKskU48+tZsx+D3wzg==",
+        "asn1": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+          "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
           "requires": {
-            "@types/async": "^2.0.48",
-            "@types/clone-deep": "^4.0.1",
-            "@types/express": "^4.11.1",
-            "@types/form-data": "^2.2.1",
-            "@types/jsonwebtoken": "^7.2.6",
-            "@types/node": "^9.6.1",
-            "@types/request": "^2.47.0",
-            "@types/sprintf-js": "^1.1.0",
-            "@types/url-join": "^0.8.1",
-            "async": "^1.5.2",
-            "base64url": "^3.0.0",
-            "chrono-node": "^1.1.3",
-            "clone-deep": "^4.0.1",
-            "jsonwebtoken": "^8.2.2",
-            "promise": "^7.1.1",
-            "request": "^2.88.0",
-            "rsa-pem-from-mod-exp": "^0.8.4",
-            "sprintf-js": "^1.0.3",
-            "url-join": "^1.1.0"
-          },
-          "dependencies": {
-            "@types/node-fetch": {
-              "version": "2.5.10",
-              "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
-              "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
-              "requires": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-              },
-              "dependencies": {
-                "@types/node": {
-                  "version": "15.12.0",
-                  "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.0.tgz",
-                  "integrity": "sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw=="
-                }
-              }
-            },
-            "adal-node": {
-              "version": "0.2.2",
-              "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.2.tgz",
-              "integrity": "sha512-luzQ9cXOjUlZoCiWeYbyR+nHwScSrPTDTbOInFphQs/PnwNz6wAIVkbsHEXtvYBnjLctByTTI8ccfpGX100oRQ==",
-              "requires": {
-                "@types/node": "^8.0.47",
-                "async": "^2.6.3",
-                "axios": "^0.21.1",
-                "date-utils": "*",
-                "jws": "3.x.x",
-                "underscore": ">= 1.3.1",
-                "uuid": "^3.1.0",
-                "xmldom": ">= 0.1.x",
-                "xpath.js": "~1.1.0"
-              },
-              "dependencies": {
-                "@types/node": {
-                  "version": "8.10.66",
-                  "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-                  "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
-                },
-                "async": {
-                  "version": "2.6.3",
-                  "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-                  "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-                  "requires": {
-                    "lodash": "^4.17.14"
-                  }
-                }
-              }
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-            },
-            "axios": {
-              "version": "0.21.1",
-              "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-              "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-              "requires": {
-                "follow-redirects": "^1.10.0"
-              }
-            },
-            "buffer-equal-constant-time": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-              "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-            },
-            "combined-stream": {
-              "version": "1.0.8",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-              "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              }
-            },
-            "date-utils": {
-              "version": "1.2.21",
-              "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-              "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-            },
-            "ecdsa-sig-formatter": {
-              "version": "1.0.11",
-              "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-              "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "follow-redirects": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-              "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
-            },
-            "form-data": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-              "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "jwa": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-              "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-              "requires": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "jws": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-              "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-              "requires": {
-                "jwa": "^1.4.1",
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "lodash": {
-              "version": "4.17.21",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-            },
-            "mime-db": {
-              "version": "1.48.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-              "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
-            },
-            "mime-types": {
-              "version": "2.1.31",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-              "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-              "requires": {
-                "mime-db": "1.48.0"
-              }
-            },
-            "node-fetch": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-              "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-            },
-            "safe-buffer": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-            },
-            "underscore": {
-              "version": "1.13.1",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-              "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
-            },
-            "uuid": {
-              "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-            },
-            "xmldom": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-              "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
-            },
-            "xpath.js": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-              "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
-            }
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+        },
+        "aws4": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+        },
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "buffer-equal-constant-time": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+          "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+        },
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "date-utils": {
+          "version": "1.2.21",
+          "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+          "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA=="
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ecdsa-sig-formatter": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
           }
         },
         "extend": {
@@ -2100,36 +1672,157 @@
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+        },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+        },
+        "follow-redirects": {
+          "version": "1.15.3",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+          "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
           }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+        },
+        "json-schema": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+        },
+        "jsprim": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+          "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.4.0",
+            "verror": "1.10.0"
+          }
+        },
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
           "requires": {
-            "mime-db": "1.43.0"
+            "mime-db": "1.52.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
           }
         },
         "oauth-sign": {
@@ -2137,10 +1830,25 @@
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+        },
+        "psl": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+          "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+        },
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+        },
+        "qs": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
         },
         "request": {
           "version": "2.88.2",
@@ -2167,12 +1875,45 @@
             "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "form-data": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+              "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+              }
+            }
           }
         },
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "sshpk": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+          "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
         },
         "tough-cookie": {
           "version": "2.5.0",
@@ -2183,22 +1924,100 @@
             "punycode": "^2.1.1"
           }
         },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+        },
+        "underscore": {
+          "version": "1.13.6",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+          "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+        },
+        "undici-types": {
+          "version": "5.26.5",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+          "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
         "url-join": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
+          "integrity": "sha512-zz1wZk4Lb5PTVwZ3HWDmm8XnlPvmOof6/fjdDPA5yBrUcbtV64U6bV832Zf1BtU2WkBBWaUT46wCs+l0HP5nhg=="
         },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "verror": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "xpath.js": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+          "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
         }
       }
     },
+    "botbuilder-teams": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/botbuilder-teams/-/botbuilder-teams-0.2.9.tgz",
+      "integrity": "sha512-aLb3pdGAZaBPBZaVcjxSnzuQPIiL4AIFIxmLl4pJBdve+FXZesS7ZOCMrotsAea9bj0HoYffqpYaFAT4UHQbuA==",
+      "requires": {
+        "adaptivecards": "^1.0.0",
+        "botbuilder": "^3.30.0",
+        "crypto": "^1.0.1",
+        "ms-rest": "^2.5.0",
+        "sprintf-js": "^1.1.1",
+        "tsc": "^1.20150623.0"
+      }
+    },
     "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2209,20 +2028,38 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "optional": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-request": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
+      "integrity": "sha512-YyNI4qJJ+piQG6MMEuo7J3Bzaqssufx04zpEKYfSrl/1Op59HWali9zMtBpXnkmqMcOuWJPZvudrm9wISmnCbg=="
     },
     "btoa": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
       "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -2233,6 +2070,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "bytestreamjs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-1.1.3.tgz",
+      "integrity": "sha512-JDGoiJ+yt+4Ui1e/vMWx5TRvmnErBBbsOkprXgbe1fRp2XZzI8MoknoiR/ZVCya9aWJbOhrJ5Heon1wrAdftkg=="
     },
     "call-bind": {
       "version": "1.0.5",
@@ -2268,17 +2110,22 @@
         }
       }
     },
+    "chardet": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.6.0.tgz",
+      "integrity": "sha512-+QOTw3otC4+FxdjK9RopGpNOglADbr4WPFi0SonkO99JbpkTPbMxmdm4NenhF5Zs+4gPXLI1+y2uazws5TMe8w=="
+    },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chrono-node": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.11.tgz",
-      "integrity": "sha1-uGomt+MVftzE/jN04bb5DK7cjjk=",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.4.8.tgz",
+      "integrity": "sha512-WwfW4/+i1e6tHx5opw/VCfxXnai12/tT5GK+wSHwKtdb0ZkAoxRGIfL8IzuFr/JEQTw4DxevysyX6+YbZSRKLQ==",
       "requires": {
-        "moment": "2.21.0"
+        "dayjs": "^1.8.19"
       }
     },
     "cli-table": {
@@ -2302,13 +2149,6 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-        }
       }
     },
     "co": {
@@ -2339,6 +2179,21 @@
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "optional": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "optional": true
+    },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
@@ -2356,6 +2211,12 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
+    },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2407,12 +2268,12 @@
     "core-decorators": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
-      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
+      "integrity": "sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA=="
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2422,7 +2283,7 @@
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
       "requires": {
         "lru-cache": "^4.0.1",
         "which": "^1.2.9"
@@ -2457,9 +2318,9 @@
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "crypto-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "ctype": {
       "version": "0.5.3",
@@ -2471,6 +2332,22 @@
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA=="
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      },
+      "dependencies": {
+        "type": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+        }
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2479,10 +2356,10 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "date-utils": {
-      "version": "1.2.21",
-      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-      "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA=="
+    "dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "ddp.js": {
       "version": "0.5.0",
@@ -2498,9 +2375,9 @@
       }
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "define-data-property": {
       "version": "1.1.1",
@@ -2533,9 +2410,18 @@
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
+    "duration": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
+      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.46"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2549,7 +2435,7 @@
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2571,13 +2457,26 @@
       "requires": {
         "esprima": "^4.0.0",
         "through": "~2.3.4"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "requires": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-promise": {
@@ -2593,6 +2492,15 @@
         "es6-promise": "^4.0.3"
       }
     },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2606,34 +2514,50 @@
     "escodegen": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "integrity": "sha512-yhi5S+mNTOuRvyW4gWlg5W1byMaQGWWSYHXsuFZ7GBo7tpyOwi2EdzMP/QWxh9hwkD2m+wDVHJsxhRIj+v/b/A==",
       "requires": {
         "esprima": "^2.7.1",
         "estraverse": "^1.9.1",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.2.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A=="
+        }
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "estraverse": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+      "integrity": "sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA=="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -2648,12 +2572,58 @@
         "original": ">=0.0.5"
       }
     },
-    "exif": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/exif/-/exif-0.6.0.tgz",
-      "integrity": "sha1-YKYmaAdlQst+T1cZnUrG830sX0o=",
+    "exifr": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-5.0.6.tgz",
+      "integrity": "sha512-iDB4IhKoKVF+uDDrHRlyNxWqGaTxYluVWqvBWVG54HkQZe8qkFYl9eQrjEP3d8Q4UMBZ9rWu3Pa+mfC+o4CZuw=="
+    },
+    "expo-modules-autolinking": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-0.0.3.tgz",
+      "integrity": "sha512-azkCRYj/DxbK4udDuDxA9beYzQTwpJ5a9QA0bBgha2jHtWdFGF4ZZWSY+zNA5mtU3KqzYt8jWHfoqgSvKyu1Aw==",
+      "optional": true,
       "requires": {
-        "debug": "^2.2"
+        "chalk": "^4.1.0",
+        "commander": "^7.2.0",
+        "fast-glob": "^3.2.5",
+        "find-up": "~5.0.0",
+        "fs-extra": "^9.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "optional": true
+        }
+      }
+    },
+    "expo-random": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-13.4.0.tgz",
+      "integrity": "sha512-Z/Bbd+1MbkK8/4ukspgA3oMlcu0q3YTCu//7q2xHwy35huN6WCv4/Uw2OGyCiOQjAbU02zwq6swA+VgVmJRCEw==",
+      "optional": true,
+      "requires": {
+        "base64-js": "^1.3.0"
       }
     },
     "express": {
@@ -2762,6 +2732,14 @@
         "basic-auth": "^2.0.1"
       }
     },
+    "ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "requires": {
+        "type": "^2.7.2"
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -2782,6 +2760,19 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
+    "fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "optional": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2790,7 +2781,16 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "optional": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "faye-websocket": {
       "version": "0.11.4",
@@ -2801,9 +2801,23 @@
       }
     },
     "file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "optional": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -2837,7 +2851,17 @@
     "find-root": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
-      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
+      "integrity": "sha512-GyDxVgA61TZcrgDJPqOqGBpi80Uf2yIstubgizi7AjC9yPdRrqBR+Y0MvK4kXnYlaoz3d+SGxDHMYVkwI/yd2w=="
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "optional": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
     },
     "flowdock": {
       "version": "0.9.1",
@@ -2860,7 +2884,8 @@
         },
         "async": {
           "version": "2.6.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
           "requires": {
             "lodash": "^4.17.10"
           }
@@ -3049,6 +3074,18 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
+    "fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "optional": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs-jetpack": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-0.13.3.tgz",
@@ -3100,13 +3137,22 @@
     "glob": {
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
       "requires": {
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "2 || 3",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "optional": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "global": {
@@ -3119,9 +3165,9 @@
       }
     },
     "gm": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
-      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.25.0.tgz",
+      "integrity": "sha512-4kKdWXTtgQ4biIo7hZA396HT062nDVVHPjQcurNZ3o/voYN+o5FUC5kOwuORbpExp3XbTJ3SU7iRipiIhQtovw==",
       "requires": {
         "array-parallel": "~0.1.3",
         "array-series": "~0.1.5",
@@ -3152,25 +3198,24 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "optional": true
+    },
     "handlebars": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.14.tgz",
-      "integrity": "sha512-E7tDoyAA8ilZIV3xDJgl18sX3M8xB9/fMw8+mfW4msLW8jlX97bAnWgT3pmaNXuvzIEgSBMnAHfuXsB2hdzfow==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "requires": {
-        "async": "^2.5.0",
-        "optimist": "^0.6.1",
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3201,9 +3246,10 @@
       }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "optional": true
     },
     "has-property-descriptors": {
       "version": "1.0.1",
@@ -3361,22 +3407,20 @@
       "integrity": "sha1-zqF+eCzndrdD9lOTk1s0MMLoGXw="
     },
     "hubot-irc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.0.tgz",
-      "integrity": "sha1-qV1cMshnAtljJOgnZWrUV65fT1o=",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.2.tgz",
+      "integrity": "sha512-Dj/v9WElKYEm/9iBpYf1yidGe5WPpe8Ir2tWccc3vGLv7B3DbJ5JJIqfBRpK4P6LbuBZfdirCBHS5ALaWNItmg==",
       "requires": {
-        "irc": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
+        "irc": "github:matrix-org/node-irc",
         "log": "1.4.0"
       }
     },
     "hubot-matteruser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.2.0.tgz",
-      "integrity": "sha1-YeDZDemcwS4QC5HpyTJGPSggZl0=",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.4.6.tgz",
+      "integrity": "sha512-G6zo19ODGrG2cz6458U+He3fdG1I/bSa0x+SI6HZjB429d5fKMkSkqGIdscLs5j1fs4nYH+9oGkhIrODMv5E7A==",
       "requires": {
-        "mattermost-client": "^6.1.0",
-        "parent-require": "^1.0.0",
-        "q": "^1.4.1"
+        "mattermost-client": "^6.5.0"
       }
     },
     "hubot-redis-brain": {
@@ -3475,7 +3519,7 @@
         "request": {
           "version": "2.9.3",
           "resolved": "https://registry.npmjs.org/request/-/request-2.9.3.tgz",
-          "integrity": "sha1-rArCYWlWiDfSiGqSsiwL0eFeetc="
+          "integrity": "sha512-SyyCqkxodKeOkoQqbLfLnwSGmVP/HXI3/CedADYEzH0Txml8P1p2XNyhfCJR9ejk8yqPMftdeYXH9+Oi0liX6Q=="
         }
       }
     },
@@ -3495,9 +3539,9 @@
       }
     },
     "hubot-xmpp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/hubot-xmpp/-/hubot-xmpp-0.2.5.tgz",
-      "integrity": "sha1-/8PfqqejTVSz2SPqcWcRLErcnB0=",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/hubot-xmpp/-/hubot-xmpp-0.2.6.tgz",
+      "integrity": "sha512-JqByL+unUz0WZYp0Miovr7iiHwkgISJLMiL9FBEdovYZwsSmZegixyqm0y5L7bIklz57J2oIs/jrY0DitKCt/A==",
       "requires": {
         "node-xmpp-client": "3.0.0",
         "uuid": "2.0.2"
@@ -3505,18 +3549,9 @@
       "dependencies": {
         "uuid": {
           "version": "2.0.2",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-          "integrity": "sha1-SL1WmPBnfjx5AaHEbvFbFkN5RyY="
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+          "integrity": "sha512-BooSif/UQWXwaQme+4z32duvmtUUz/nlHsyGrrSCgsGf6snMrp9q/n1nGHwQzU12kaCeceODmAiRZA8TCK06jA=="
         }
-      }
-    },
-    "iconv": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.2.3.tgz",
-      "integrity": "sha1-4ITWDut9c9p/CpwJbkyKvgkL+u0=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.3.5"
       }
     },
     "iconv-lite": {
@@ -3527,10 +3562,15 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3541,34 +3581,69 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "optional": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "ip-anonymize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ip-anonymize/-/ip-anonymize-0.1.0.tgz",
+      "integrity": "sha512-cZJu+N5JKKFGMK0eEQWNaQMn2EhCysciVM6eotCJwfqotj16BTfVchKsJCH6mQAT9N0GC7oWRcsZ6Lb8dDiwTA=="
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "irc": {
-      "version": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
-      "from": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
+      "version": "github:matrix-org/node-irc#b684a46d11a9f0045f237d423bb83eb78b4eec39",
+      "from": "github:matrix-org/node-irc",
       "requires": {
-        "iconv": "~2.2.1",
-        "irc-colors": "^1.1.0",
-        "node-icu-charset-detector": "~0.2.0"
+        "chardet": "^1.5.1",
+        "iconv-lite": "^0.6.3",
+        "typed-emitter": "^2.1.0",
+        "utf-8-validate": "^6.0.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
-    },
-    "irc-colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.5.0.tgz",
-      "integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "optional": true
+    },
     "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "optional": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
@@ -3587,6 +3662,12 @@
         "xtend": "^4.0.0"
       }
     },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "optional": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3594,6 +3675,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w=="
     },
     "is-property": {
       "version": "1.0.2",
@@ -3603,7 +3689,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3618,12 +3704,30 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+    },
+    "isomorphic-webcrypto": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/isomorphic-webcrypto/-/isomorphic-webcrypto-2.3.8.tgz",
+      "integrity": "sha512-XddQSI0WYlSCjxtm1AI8kWQOulf7hAN3k3DclF1sxDJZqOe0pcsOt675zvWW91cZH9hYs3nlA3Ev8QK5i80SxQ==",
+      "requires": {
+        "@peculiar/webcrypto": "^1.0.22",
+        "@unimodules/core": "*",
+        "@unimodules/react-native-adapter": "*",
+        "asmcrypto.js": "^0.22.0",
+        "b64-lite": "^1.3.1",
+        "b64u-lite": "^1.0.1",
+        "expo-random": "*",
+        "msrcrypto": "^1.5.6",
+        "react-native-securerandom": "^0.1.1",
+        "str2buf": "^1.3.0",
+        "webcrypto-shim": "^0.1.4"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -3633,7 +3737,7 @@
     "istanbul": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "integrity": "sha512-nMtdn4hvK0HjUlzr1DrKSUY8ychprt8dzHOgY2KXsIhHu5PuQQEOTM27gV9Xblyon7aUH/TSFIjRHEODF/FRPg==",
       "requires": {
         "abbrev": "1.0.x",
         "async": "1.x",
@@ -3649,6 +3753,26 @@
         "supports-color": "^3.1.0",
         "which": "^1.1.1",
         "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A=="
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA=="
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "javascript-state-machine": {
@@ -3656,20 +3780,19 @@
       "resolved": "https://registry.npmjs.org/javascript-state-machine/-/javascript-state-machine-3.1.0.tgz",
       "integrity": "sha512-BwhYxQ1OPenBPXC735RgfB+ZUG8H3kjsx8hrYTgWnoy6TPipEy4fiicyhT2lxRKAXq9pG7CfFT8a2HLr6Hmwxg=="
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "optional": true
+    },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
-        }
       }
     },
     "jsbn": {
@@ -3693,6 +3816,16 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
@@ -3701,7 +3834,7 @@
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -3716,9 +3849,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -3736,7 +3869,7 @@
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3746,7 +3879,7 @@
     "jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -3755,15 +3888,29 @@
     "key-tree-store": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/key-tree-store/-/key-tree-store-1.3.0.tgz",
-      "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
+      "integrity": "sha512-qXk+lR+LXvGos3wqMxIMWweKDgCx8ZKWM6BEPm7iZkOKug5ggi66vUt+3vbtKJLBrAyOxQ4S8JRwK++Q4XZRmw=="
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "optional": true,
+      "requires": {
+        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -3774,17 +3921,17 @@
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A=="
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
       "requires": {
         "lodash._basecopy": "^3.0.0",
         "lodash.keys": "^3.0.0"
@@ -3793,7 +3940,7 @@
     "lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
       "requires": {
         "lodash._arraycopy": "^3.0.0",
         "lodash._arrayeach": "^3.0.0",
@@ -3806,22 +3953,22 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ=="
     },
     "lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A=="
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ=="
     },
     "lodash._createassigner": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "integrity": "sha512-LziVL7IDnJjQeeV95Wvhw6G28Z8Q6da87LWKOPWmzBLv4u6FAT/x5v00pyGW0u38UoogNF2JnD3bGgZZDaNEBw==",
       "requires": {
         "lodash._bindcallback": "^3.0.0",
         "lodash._isiterateecall": "^3.0.0",
@@ -3831,17 +3978,17 @@
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA=="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+      "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ=="
     },
     "lodash.assign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+      "integrity": "sha512-/VVxzgGBmbphasTg51FrztxQJ/VgAUpol6zmJuSVSGcNg4g7FA4z7rQV8Ovr9V3vFBNWZhvKWHfpAytjTVUfFA==",
       "requires": {
         "lodash._baseassign": "^3.0.0",
         "lodash._createassigner": "^3.0.0",
@@ -3849,118 +3996,83 @@
       }
     },
     "lodash.clone": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+      "integrity": "sha512-yVYPpFTdZDCLG2p07gVRTvcwN5X04oj2hu4gG6r0fer58JA08wAVxXzWM+CmmxO2bzOH8u8BkZTZqgX6juVF7A==",
+      "requires": {
+        "lodash._baseclone": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
       "requires": {
         "lodash._baseclone": "^3.0.0",
         "lodash._bindcallback": "^3.0.0"
       }
     },
-    "lodash.fill": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.fill/-/lodash.fill-3.4.0.tgz",
-      "integrity": "sha1-o8dK5kDQU63w3CB5+HIHiOi/74U="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.intersection": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
-      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ=="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
       "requires": {
         "lodash._getnative": "^3.0.0",
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
     },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-    },
-    "lodash.partialright": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
-      "integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+      "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw=="
     },
     "log": {
       "version": "1.4.0",
@@ -3968,9 +4080,18 @@
       "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
     "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "optional": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -3982,23 +4103,187 @@
       }
     },
     "ltx": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
-      "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.10.0.tgz",
+      "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "mattermost-client": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.1.0.tgz",
-      "integrity": "sha1-cw5BLw8BTvq2GiHbKN8S8gqIgSY=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.5.0.tgz",
+      "integrity": "sha512-4Nqg8k3lF/Mr5DGt3s0cZfNm+hF/YTKaIDVQJNGuB0TiaE7/BSJMcpwKdoBjz4ztruWNaV+oBAofrUILwT1EcA==",
       "requires": {
-        "https-proxy-agent": "^2.1.0",
-        "log": "^1.4.0",
-        "request": "^2.73.0",
-        "text-encoding": "^0.5.5",
-        "ws": "^1.0.1"
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "log": "^6.1.0",
+        "request": "^2.88.0",
+        "set-value": ">=4.0.1",
+        "text-encoding": "^0.7.0",
+        "ws": ">=3.3.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "aws4": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "har-validator": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+          "requires": {
+            "ajv": "^6.12.3",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "log": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
+          "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
+          "requires": {
+            "d": "^1.0.1",
+            "duration": "^0.2.2",
+            "es5-ext": "^0.10.53",
+            "event-emitter": "^0.3.5",
+            "sprintf-kit": "^2.0.1",
+            "type": "^2.5.0",
+            "uni-global": "^1.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+          "requires": {
+            "mime-db": "1.52.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "ws": {
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
+        }
       }
     },
     "md5": {
@@ -4021,10 +4306,26 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "optional": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "optional": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -4047,7 +4348,7 @@
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -4061,29 +4362,22 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.6"
       }
     },
     "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha1-KhFLUdKm7J5tg8+AP4OKh42KAjo="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.0.0",
@@ -4091,24 +4385,26 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "ms-rest": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.4.tgz",
-      "integrity": "sha512-VeqCbawxRM6nhw0RKNfj7TWL7SL8PB6MypqwgylXCi+u412uvYoyY/kSmO8n06wyd8nIcnTbYToCmSKFMI1mCg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.6.tgz",
+      "integrity": "sha512-3Scy/pF43wqPEPeJxhOsLs16m6Rt+9zqf+jKdg+guuonytKmFSxerQM2exlQIDTqFVTsLXrPEGFWTGSwivRRkA==",
       "requires": {
+        "ajv": "6.12.3",
         "duplexer": "^0.1.1",
+        "http-signature": "1.3.6",
         "is-buffer": "^1.1.6",
         "is-stream": "^1.1.0",
         "moment": "^2.21.0",
-        "request": "^2.88.0",
+        "request": "^2.88.2",
         "through": "^2.3.8",
         "tunnel": "0.0.5",
         "uuid": "^3.2.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -4117,9 +4413,9 @@
           }
         },
         "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "extend": {
           "version": "3.0.2",
@@ -4127,17 +4423,27 @@
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+          "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^2.0.2",
+            "sshpk": "^1.14.1"
           }
         },
         "json-schema-traverse": {
@@ -4145,17 +4451,28 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
+        "jsprim": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+          "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.4.0",
+            "verror": "1.10.0"
+          }
+        },
         "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
           "requires": {
-            "mime-db": "1.43.0"
+            "mime-db": "1.52.0"
           }
         },
         "oauth-sign": {
@@ -4164,9 +4481,9 @@
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "request": {
           "version": "2.88.2",
@@ -4195,6 +4512,27 @@
             "uuid": "^3.3.2"
           },
           "dependencies": {
+            "http-signature": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+              "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+              "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+              }
+            },
+            "jsprim": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+              "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.4.0",
+                "verror": "1.10.0"
+              }
+            },
             "uuid": {
               "version": "3.4.0",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -4212,6 +4550,11 @@
           }
         }
       }
+    },
+    "msrcrypto": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/msrcrypto/-/msrcrypto-1.5.8.tgz",
+      "integrity": "sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q=="
     },
     "multiparty": {
       "version": "4.2.3",
@@ -4257,126 +4600,97 @@
         }
       }
     },
-    "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "optional": true
-    },
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
-    "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
-    "node-icu-charset-detector": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/node-icu-charset-detector/-/node-icu-charset-detector-0.2.0.tgz",
-      "integrity": "sha1-wjINo3Tdy2cfxUy0oOBB4Vb/1jk=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.3.3"
-      }
+    "node-gyp-build": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.0.tgz",
+      "integrity": "sha512-PbZERfeFdrHQOOXiAKOY0VPbykZy90ndPKk0d+CFDegTKmWp1VgOTz2xACVbr1BjCWxrQp68CXtvNsveFhqDJg=="
     },
     "node-jose": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-0.11.1.tgz",
-      "integrity": "sha512-1mX5prmancKdOgMI/85uduqWNFg63traxVdun7dNNsX4AUs6HqztJhzfBlIWfSujQ8Rah9dWLGUFlXORxZvvzg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.2.0.tgz",
+      "integrity": "sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw==",
       "requires": {
-        "b64u": "^2.0.0",
-        "es6-promise": "^4.0.5",
-        "lodash.assign": "^4.0.8",
-        "lodash.clone": "^4.3.2",
-        "lodash.fill": "^3.2.2",
-        "lodash.flatten": "^4.2.0",
-        "lodash.intersection": "^4.1.2",
-        "lodash.merge": "^4.3.5",
-        "lodash.omit": "^4.2.1",
-        "lodash.partialright": "^4.1.3",
-        "lodash.pick": "^4.2.0",
-        "lodash.uniq": "^4.2.1",
-        "long": "^3.1.0",
-        "node-forge": "^0.7.1",
-        "uuid": "^3.0.1"
+        "base64url": "^3.0.1",
+        "buffer": "^6.0.3",
+        "es6-promise": "^4.2.8",
+        "lodash": "^4.17.21",
+        "long": "^5.2.0",
+        "node-forge": "^1.2.1",
+        "pako": "^2.0.4",
+        "process": "^0.11.10",
+        "uuid": "^9.0.0"
       },
       "dependencies": {
-        "lodash.assign": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+        "es6-promise": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         }
       }
     },
     "node-kms": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.3.2.tgz",
-      "integrity": "sha1-beflJICO7ATHf+6072SUDlDit1k=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.4.0.tgz",
+      "integrity": "sha512-Tvhs7XTvBgWLZUrAeLKDqzvlomaZWwMoIXWImMc/IbvTijLoOrkovZo+PeW0ivf/8fBlg5EihPCwKg/dy9r+sA==",
       "requires": {
         "es6-promise": "^2.0.1",
         "lodash.clone": "^3.0.2",
         "lodash.clonedeep": "^3.0.1",
-        "node-jose": ">=0.3.0 <1.0",
+        "node-jose": "^2.0.0",
         "uuid": "^2.0.1"
       },
       "dependencies": {
         "es6-promise": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
-        },
-        "lodash.clone": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
-          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
-          "requires": {
-            "lodash._baseclone": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
-          }
+          "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
         },
         "uuid": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+          "integrity": "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg=="
         }
       }
     },
     "node-scr": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.2.2.tgz",
-      "integrity": "sha1-VCqtdCAQ0S5Bm1kG2lFq+d6jBdo=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.3.0.tgz",
+      "integrity": "sha512-Hb0ykojynSbt7ra6eml6NX39WAumFfU3G81XvLpp2H7y8KjQc29oEIf2TlgZQCfA+pyxbY5t4a1xBqPpyrbpvw==",
       "requires": {
         "es6-promise": "^2.0.1",
         "lodash.clone": "^3.0.2",
-        "node-jose": ">=0.3.0 <1.0"
+        "node-jose": "^2.0.0"
       },
       "dependencies": {
         "es6-promise": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
-        },
-        "lodash.clone": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
-          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
-          "requires": {
-            "lodash._baseclone": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
-          }
+          "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
         }
       }
     },
@@ -4388,7 +4702,7 @@
     "node-xmpp-client": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.0.0.tgz",
-      "integrity": "sha1-UsxdO/fR/IbSd2pYL3x7yugCYTo=",
+      "integrity": "sha512-evWWdIBMx5AzNmj0CkCwlhosRACRTWC4W4rnhUHg1MZPmqfsIl/WPHTwQfwnQE0xL0+EUcVkUJigOzolmHfI9Q==",
       "requires": {
         "browser-request": "^0.3.3",
         "debug": "^2.2.0",
@@ -4402,7 +4716,7 @@
         "faye-websocket": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+          "integrity": "sha512-Xhj93RXbMSq8urNCUq4p9l0P6hnySJ/7YNRhYNug0bLOuii7pKO7xQFb5mx9xZXWCar88pLPb805PvUkwrLZpQ==",
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
@@ -4412,7 +4726,7 @@
     "node-xmpp-core": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-core/-/node-xmpp-core-4.2.0.tgz",
-      "integrity": "sha1-fi4EDB5apkvjUBO9w0Ey7Ddpla4=",
+      "integrity": "sha512-ZugTIR0OU3Q23b7rcsHzvxfmfjZ7+khQcWm5r+5i1kxrs85eIan2ahsUp2LtSDBzcYk+8CqDgSKh+MYue08oXg==",
       "requires": {
         "debug": "^2.2.0",
         "inherits": "^2.0.1",
@@ -4426,12 +4740,12 @@
     "node-xmpp-jid": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-jid/-/node-xmpp-jid-2.3.0.tgz",
-      "integrity": "sha1-YKPJUFgqDNz9oHRJQ1eoUXjziHg="
+      "integrity": "sha512-jSmRnpbc0brF9baWg9QZQzhyNNkobGsw0zAymWl0hsIb+CsaPpZboWJ+NGeHq89XwqC6udJjwMiUDZM3tqqFLw=="
     },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
       "requires": {
         "abbrev": "1"
       }
@@ -4470,43 +4784,22 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-        }
-      }
-    },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "options": {
@@ -4527,35 +4820,75 @@
         "url-parse": "^1.4.3"
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "optional": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "optional": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "parent-require": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
       "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
     },
     "parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "optional": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "optional": true
     },
     "pkginfo": {
       "version": "0.4.1",
@@ -4563,9 +4896,14 @@
       "integrity": "sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ=="
     },
     "pkijs": {
-      "version": "2.1.88",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.1.88.tgz",
-      "integrity": "sha512-R/1VglrBioIx3wdX1/DzEcJDvhJgl5cNsT+Ovex3zWbCwjY2mDUW2Qvj6/kc0S7PDDnijXwHczAVRYscNLhUgQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.4.0.tgz",
+      "integrity": "sha512-cjJP/mYuGyMrjJ49jI04khId5Oufd3nFTUYBzQTIIVNI7/oAWdwXEfpwTF8HELFV/gz+WGYUBHCe3KHWD8rYvg==",
+      "requires": {
+        "asn1js": "^3.0.3",
+        "bytestreamjs": "^1.0.29",
+        "pvutils": "^1.1.3"
+      },
       "dependencies": {
         "asn1js": {
           "version": "3.0.5",
@@ -4576,46 +4914,28 @@
             "pvutils": "^1.1.3",
             "tslib": "^2.4.0"
           }
-        },
-        "bytestreamjs": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
-          "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ=="
-        },
-        "pvtsutils": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-          "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        },
-        "pvutils": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-          "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -4635,9 +4955,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
       "version": "1.4.1",
@@ -4645,12 +4965,17 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "pvtsutils": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.10.tgz",
-      "integrity": "sha512-8ZKQcxnZKTn+fpDh7wL4yKax5fdl3UJzT8Jv49djZpB/dzPxacyN1Sez90b6YLdOmvIr9vaySJ5gw4aUA1EdSw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
       "requires": {
-        "tslib": "^1.10.0"
+        "tslib": "^2.6.1"
       }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
     "q": {
       "version": "1.5.1",
@@ -4666,6 +4991,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "optional": true
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -4727,6 +5058,15 @@
         }
       }
     },
+    "react-native-securerandom": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz",
+      "integrity": "sha512-CozcCx0lpBLevxiXEb86kwLRalBCHNjiGPlw3P7Fi27U6ZLdfjOCNRHD1LtBKcvPvI3TvkBXB3GOtLvqaYJLGw==",
+      "optional": true,
+      "requires": {
+        "base64-js": "*"
+      }
+    },
     "readable-stream": {
       "version": "1.0.34",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -4738,17 +5078,57 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "reconnect-core": {
       "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-      "integrity": "sha1-udryrcRbGabMX9LwSPjZQGzs5Jg=",
+      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
       "requires": {
         "backoff": "~2.3.0"
+      },
+      "dependencies": {
+        "backoff": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
+          "integrity": "sha512-ljr33cUQ/vyXE/60QuRO+WKGW4PzQ5OTWNXPWQwOTx5gh43q0pZocaVyXoU2gvFtasMIdIohdm9s01qoT6IJBQ=="
+        }
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "request": {
       "version": "2.85.0",
@@ -4787,22 +5167,54 @@
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
     },
     "retry": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
       "integrity": "sha512-bkzdIZ5Xyim12j0jq6CQAHpfdsa2VqieWF6eN8vT2MXxCxLAZhgVUyu5EEMevJyXML+XWTxVbZ7mLaKx5F/DZw=="
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "optional": true
+    },
     "rsa-pem-from-mod-exp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
-      "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.6.tgz",
+      "integrity": "sha512-c5ouQkOvGHF1qomUUDJGFcXsomeSO2gbEs6hVhMAtlkE1CuaZase/WzoaKFG/EZQuNmq6pw/EMCeEnDvOgCJYQ=="
     },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+    },
+    "rtcpeerconnection-shim": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
+      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
+      "requires": {
+        "sdp": "^2.6.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "optional": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -4814,10 +5226,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sdp": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
+      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
+    },
     "sdp-transform": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.0.tgz",
-      "integrity": "sha512-8ZYOau/o9PzRhY0aMuRzvmiM6/YVQR8yjnBScvZHSdBnywK5oZzAJK+412ZKkDq29naBmR3bRw8MFu0C01Gehg=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
+      "integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw=="
     },
     "semver": {
       "version": "5.7.2",
@@ -4918,6 +5335,15 @@
         "has-property-descriptors": "^1.0.0"
       }
     },
+    "set-value": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "is-primitive": "^3.0.1"
+      }
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -4929,13 +5355,6 @@
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "requires": {
         "kind-of": "^6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-        }
       }
     },
     "side-channel": {
@@ -4959,16 +5378,24 @@
     "source-map": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
       "optional": true,
       "requires": {
         "amdefine": ">=0.0.4"
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "sprintf-kit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
+      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
+      "requires": {
+        "es5-ext": "^0.10.53"
+      }
     },
     "sshpk": {
       "version": "1.14.1",
@@ -5006,6 +5433,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
     },
+    "str2buf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/str2buf/-/str2buf-1.3.0.tgz",
+      "integrity": "sha512-xIBmHIUHYZDP4HyoXGHYNVmxlXLXDrtFHYT0eV6IOdEj3VO9ccaF1Ejl9Oq8iFjITllpT8FhaXb4KsNmw+3EuA=="
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -5024,28 +5456,38 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+    "strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "requires": {
-        "has-flag": "^1.0.0"
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "optional": true,
+      "requires": {
+        "has-flag": "^4.0.0"
       }
     },
     "text-encoding": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.5.5.tgz",
-      "integrity": "sha1-0phF2cHyrFzrpL+GHFYYVsUjrFM="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "through2": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
       "requires": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
@@ -5054,12 +5496,30 @@
     "tls-connect": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/tls-connect/-/tls-connect-0.2.2.tgz",
-      "integrity": "sha1-HYjU9MuCmgdBtqzQXR33Pg1Wb9A="
+      "integrity": "sha512-iV92SmsU+iB+TZKeZxBRTyk8T0RAXDjpwoYjG28HMm5E0ilPfrfqidDntRL4ZswoqRv81Kx05PqbK6CN7olrKQ=="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "optional": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -5069,11 +5529,6 @@
         "punycode": "^1.4.1"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "truncate": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/truncate/-/truncate-2.1.0.tgz",
@@ -5082,12 +5537,12 @@
     "tsc": {
       "version": "1.20150623.0",
       "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU="
+      "integrity": "sha512-35dAbChm97r03rxlfPwkFrrI8WoFlrqtbskmxomtnso2fOSKWDLt3TitT2ZNHl5hQF1Su9S9w/vjmoXf5W0VWA=="
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel": {
       "version": "0.0.5",
@@ -5108,10 +5563,15 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -5140,10 +5600,18 @@
         }
       }
     },
+    "typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "requires": {
+        "rxjs": "*"
+      }
+    },
     "uglify-js": {
-      "version": "3.13.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
-      "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "optional": true
     },
     "uid-safe": {
@@ -5159,10 +5627,19 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
-    "underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+    "uni-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
+      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
+      "requires": {
+        "type": "^2.5.0"
+      }
+    },
+    "universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "optional": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -5170,17 +5647,17 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         }
       }
     },
@@ -5201,7 +5678,20 @@
     "urlsafe-base64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
-      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
+      "integrity": "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="
+    },
+    "utf-8-validate": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.3.tgz",
+      "integrity": "sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -5216,7 +5706,7 @@
     "valid-url": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "vary": {
       "version": "1.1.2",
@@ -5234,55 +5724,71 @@
       }
     },
     "webcrypto-core": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.0.19.tgz",
-      "integrity": "sha512-6XHExtfMJrpkFDh9MiJ/y7ptX0dfZi0ogxFyelqxMu1eFowxivHfIp6DKzT+ZjU66xTuNfJkfkUk1bIB3tEOgA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
       "requires": {
-        "@peculiar/asn1-schema": "^1.0.5",
-        "@peculiar/json-schema": "^1.1.10",
-        "asn1js": "^2.0.26",
-        "pvtsutils": "^1.0.10",
-        "tslib": "^1.11.1"
-      }
-    },
-    "webex": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/webex/-/webex-1.80.178.tgz",
-      "integrity": "sha512-DNMYNMPlZqRF1IrwjAmThw2jc7mtV44mz+CzMoH92UGRVYoLaDoO/kxb0nZ8NNiiH99ciUbjnGRNnJ0wa/hX4A==",
-      "requires": {
-        "@webex/internal-plugin-calendar": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-presence": "1.80.178",
-        "@webex/plugin-attachment-actions": "1.80.178",
-        "@webex/plugin-authorization": "1.80.178",
-        "@webex/plugin-device-manager": "1.80.178",
-        "@webex/plugin-logger": "1.80.178",
-        "@webex/plugin-meetings": "1.80.178",
-        "@webex/plugin-memberships": "1.80.178",
-        "@webex/plugin-messages": "1.80.178",
-        "@webex/plugin-people": "1.80.178",
-        "@webex/plugin-rooms": "1.80.178",
-        "@webex/plugin-team-memberships": "1.80.178",
-        "@webex/plugin-teams": "1.80.178",
-        "@webex/plugin-webhooks": "1.80.178",
-        "@webex/storage-adapter-local-storage": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-polyfill": "^6.26.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        "asn1js": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+          "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+          "requires": {
+            "pvtsutils": "^1.3.2",
+            "pvutils": "^1.1.3",
+            "tslib": "^2.4.0"
+          }
         }
       }
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    "webcrypto-shim": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
+      "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
+    },
+    "webex": {
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-1.161.0.tgz",
+      "integrity": "sha512-fEheKltkfHrZCNHtZPHZjLPicb47JiKQzKcO/J+26n6snYsLnmhU0y8BHsbWkuudD1RuXZV/kFBSd6/nzWFO4w==",
+      "requires": {
+        "@babel/polyfill": "^7.12.1",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-calendar": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-presence": "1.161.0",
+        "@webex/internal-plugin-support": "1.161.0",
+        "@webex/plugin-attachment-actions": "1.161.0",
+        "@webex/plugin-authorization": "1.161.0",
+        "@webex/plugin-device-manager": "1.161.0",
+        "@webex/plugin-logger": "1.161.0",
+        "@webex/plugin-meetings": "1.161.0",
+        "@webex/plugin-memberships": "1.161.0",
+        "@webex/plugin-messages": "1.161.0",
+        "@webex/plugin-people": "1.161.0",
+        "@webex/plugin-rooms": "1.161.0",
+        "@webex/plugin-team-memberships": "1.161.0",
+        "@webex/plugin-teams": "1.161.0",
+        "@webex/plugin-webhooks": "1.161.0",
+        "@webex/storage-adapter-local-storage": "1.161.0",
+        "@webex/webex-core": "1.161.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "webrtc-adapter": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
+      "integrity": "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==",
+      "requires": {
+        "rtcpeerconnection-shim": "^1.2.15",
+        "sdp": "^2.12.0"
+      }
     },
     "websocket-driver": {
       "version": "0.7.0",
@@ -5298,19 +5804,10 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -5335,15 +5832,20 @@
         }
       }
     },
+    "word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
       "version": "1.1.5",
@@ -5354,11 +5856,6 @@
         "ultron": "1.0.x"
       }
     },
-    "xpath.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
-    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -5368,6 +5865,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "optional": true
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -35,13 +35,6 @@
       "integrity": "sha512-1lc1ptKNT+f6eS9FA7sJPAeqjM00xfwcEU6fBjVa6VLPI0pjGJHRoxBuA2ghQ16TyjilDnCxZb6dQl+WW54CKg==",
       "requires": {
         "source-map": "^0.5.6"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -114,8 +107,8 @@
     },
     "@rocket.chat/sdk": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/@rocket.chat/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha1-uFcXq9gf1bSFcm62tgno8bUKuBg=",
+      "resolved": "https://registry.npmjs.org/@rocket.chat/sdk/-/sdk-0.1.0.tgz",
+      "integrity": "sha512-KPN8RuAfaGQg0R/MguvlnwNFKm4UI84U7g0YYOVIc6rzpGc+ON2dh/sLyoEtJdDKGwOtF9oogs14mMO3cLHkFA==",
       "requires": {
         "@types/lru-cache": "^4.1.0",
         "@types/node": "^9.4.6",
@@ -142,10 +135,49 @@
         "ws": "^1.0.1"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "bluebird": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "url-join": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+          "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw=="
+        },
+        "ws": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
         }
       }
     },
@@ -230,9 +262,9 @@
       }
     },
     "@types/lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-sth6Xj341LGMpCbFEFzXAcIwbUA="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-QjCOmf5kYwekcsfEKhcEHMK8/SvgnneuSDXFERBuC/DPca2KJIO/gpChTsVb35BoWLBpEAJWz1GFVEArSdtKtw=="
     },
     "@types/mime": {
       "version": "1.3.5",
@@ -240,9 +272,9 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
-      "version": "9.6.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.36.tgz",
-      "integrity": "sha1-xKK9sW06ebNOAUZLS9OMG4Se/aw="
+      "version": "9.6.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
+      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
     },
     "@types/qs": {
       "version": "6.9.10",
@@ -345,13 +377,6 @@
         "lodash": "^4.17.21",
         "safe-buffer": "^5.2.0",
         "urlsafe-base64": "^1.0.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
       }
     },
     "@webex/common-timers": {
@@ -392,11 +417,6 @@
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
           "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -419,69 +439,6 @@
         "xtend": "^4.0.2"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "aws4": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "mime-db": {
-          "version": "1.52.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-          "version": "2.1.35",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-          "requires": {
-            "mime-db": "1.52.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
-        "punycode": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-        },
         "qs": {
           "version": "6.11.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
@@ -489,64 +446,6 @@
           "requires": {
             "side-channel": "^1.0.4"
           }
-        },
-        "request": {
-          "version": "2.88.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "qs": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-              "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         }
       }
     },
@@ -582,13 +481,6 @@
         "lodash": "^4.17.21",
         "node-scr": "^0.3.0",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
       }
     },
     "@webex/internal-plugin-device": {
@@ -640,16 +532,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -698,18 +580,6 @@
         "lodash": "^4.17.21",
         "uuid": "^3.3.2",
         "ws": "^8.2.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "ws": {
-          "version": "8.14.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
-        }
       }
     },
     "@webex/internal-plugin-metrics": {
@@ -762,13 +632,6 @@
         "envify": "^4.1.0",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
       }
     },
     "@webex/internal-plugin-user": {
@@ -806,11 +669,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -837,13 +695,6 @@
         "envify": "^4.1.0",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
       }
     },
     "@webex/plugin-authorization-node": {
@@ -871,13 +722,6 @@
         "envify": "^4.1.0",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
       }
     },
     "@webex/plugin-logger": {
@@ -926,11 +770,6 @@
             "util-deprecate": "^1.0.1"
           }
         },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
         "string_decoder": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -938,11 +777,6 @@
           "requires": {
             "safe-buffer": "~5.2.0"
           }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -968,11 +802,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -1023,11 +852,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -1090,13 +914,6 @@
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
       }
     },
     "abbrev": {
@@ -1111,21 +928,6 @@
       "requires": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.52.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-          "version": "2.1.35",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-          "requires": {
-            "mime-db": "1.52.0"
-          }
-        }
       }
     },
     "adaptivecards": {
@@ -1134,22 +936,37 @@
       "integrity": "sha512-/l34rvdRzQ20QdGLk+awRUotexu3N4Ih3O0qR8cM+2wWe0pggvWhmFdwVFmM+YgIS5pWtl2u7XAJynUaFIQAIw=="
     },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "amdefine": {
@@ -1210,12 +1027,12 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -1263,9 +1080,12 @@
       "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "asn1js": {
       "version": "2.4.0",
@@ -1278,7 +1098,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
     },
     "asteroid": {
       "version": "github:rocketchat/asteroid#a76a53254e381f9487aa2a9be3d874c9a2df6552",
@@ -1291,13 +1111,13 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -1308,12 +1128,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "axios": {
       "version": "0.21.4",
@@ -1373,29 +1193,35 @@
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
         "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
       "version": "0.9.5",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha512-njlCs8XLBIK7LCChTWfzWuIAxkpmmLXcL7/igCofFT1B039Sz0IPnAmosN5QaO22lU4qr8LcUz2ojUlE6pLkRQ==",
       "requires": {
         "readable-stream": "~1.0.26"
       }
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ=="
     },
     "body-parser": {
       "version": "1.20.1",
@@ -1433,11 +1259,6 @@
             "toidentifier": "1.0.1"
           }
         },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
         "on-finished": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -1472,11 +1293,11 @@
       }
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "2.x.x"
       }
     },
     "botbuilder": {
@@ -1503,502 +1324,6 @@
         "rsa-pem-from-mod-exp": "^0.8.4",
         "sprintf-js": "^1.0.3",
         "url-join": "^1.1.0"
-      },
-      "dependencies": {
-        "@types/node-fetch": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
-          "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
-          "requires": {
-            "@types/node": "*",
-            "form-data": "^4.0.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "20.9.4",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.4.tgz",
-              "integrity": "sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==",
-              "requires": {
-                "undici-types": "~5.26.4"
-              }
-            }
-          }
-        },
-        "@xmldom/xmldom": {
-          "version": "0.8.10",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-          "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
-        },
-        "adal-node": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.4.tgz",
-          "integrity": "sha512-zIcvbwQFKMUtKxxj8YMHeTT1o/TPXfVNsTXVgXD8sxwV6h4AFQgK77dRciGhuEF9/Sdm3UQPJVPc/6XxrccSeA==",
-          "requires": {
-            "@xmldom/xmldom": "^0.8.3",
-            "async": "^2.6.3",
-            "axios": "^0.21.1",
-            "date-utils": "*",
-            "jws": "3.x.x",
-            "underscore": ">= 1.3.1",
-            "uuid": "^3.1.0",
-            "xpath.js": "~1.1.0"
-          },
-          "dependencies": {
-            "async": {
-              "version": "2.6.4",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-              "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-              "requires": {
-                "lodash": "^4.17.14"
-              }
-            }
-          }
-        },
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "asn1": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-          "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
-        },
-        "aws4": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
-        },
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-          "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "buffer-equal-constant-time": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-          "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "date-utils": {
-          "version": "1.2.21",
-          "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-          "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA=="
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-          "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ecdsa-sig-formatter": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-        },
-        "follow-redirects": {
-          "version": "1.15.3",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-          "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
-        },
-        "json-schema": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-        },
-        "jsprim": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-          "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.4.0",
-            "verror": "1.10.0"
-          }
-        },
-        "jwa": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-          "requires": {
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "jws": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-          "requires": {
-            "jwa": "^1.4.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "mime-db": {
-          "version": "1.52.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-          "version": "2.1.35",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-          "requires": {
-            "mime-db": "1.52.0"
-          }
-        },
-        "node-fetch": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-        },
-        "psl": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-          "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-        },
-        "punycode": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-        },
-        "qs": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
-        },
-        "request": {
-          "version": "2.88.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "form-data": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-              "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "sshpk": {
-          "version": "1.18.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-          "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-        },
-        "underscore": {
-          "version": "1.13.6",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-          "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
-        },
-        "undici-types": {
-          "version": "5.26.5",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-          "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
-        },
-        "uri-js": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "url-join": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha512-zz1wZk4Lb5PTVwZ3HWDmm8XnlPvmOof6/fjdDPA5yBrUcbtV64U6bV832Zf1BtU2WkBBWaUT46wCs+l0HP5nhg=="
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        },
-        "xpath.js": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-          "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
-        }
       }
     },
     "botbuilder-teams": {
@@ -2064,7 +1389,7 @@
     "buffer-indexof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow="
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "bytes": {
       "version": "3.1.2",
@@ -2089,25 +1414,18 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "chardet": {
@@ -2118,7 +1436,7 @@
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
     },
     "chrono-node": {
       "version": "1.4.8",
@@ -2151,11 +1469,6 @@
         "shallow-clone": "^3.0.0"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "coffee-register": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/coffee-register/-/coffee-register-1.0.0.tgz",
@@ -2165,13 +1478,6 @@
         "coffee-script": "^1.12.5",
         "fs-jetpack": "^0.13.3",
         "md5": "^2.2.1"
-      },
-      "dependencies": {
-        "coffee-script": {
-          "version": "1.12.7",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-          "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
-        }
       }
     },
     "coffee-script": {
@@ -2197,20 +1503,20 @@
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw=="
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "compare-versions": {
       "version": "3.6.0",
@@ -2241,13 +1547,6 @@
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "requires": {
         "safe-buffer": "5.2.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
       }
     },
     "content-type": {
@@ -2278,7 +1577,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "cross-spawn": {
       "version": "4.0.2",
@@ -2292,24 +1591,14 @@
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==",
       "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        }
+        "boom": "2.x.x"
       }
     },
     "crypto": {
@@ -2324,8 +1613,8 @@
     },
     "ctype": {
       "version": "0.5.3",
-      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha512-T6CEkoSV4q50zW3TlTHMbzy1E5+zlnNcY+yb7tWVYlTwPhx9LpnfAkd4wecpWknDyptp4k97LUZeInlf6jdzBg=="
     },
     "cycle": {
       "version": "1.0.3",
@@ -2351,7 +1640,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2364,14 +1653,21 @@
     "ddp.js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ddp.js/-/ddp.js-0.5.0.tgz",
-      "integrity": "sha1-+XfuQgeDhXEgO/eB2vtXHQrr1mo="
+      "integrity": "sha512-jDsrOfTusxHLrUTZt6q/WeZk90TEcVRKTY5uIHJ1zu1Z65eXfrl6DvUdgf1JdwkYeCaSUvuAXKEkDNsxDQiJhQ=="
     },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
       }
     },
     "deep-is": {
@@ -2392,7 +1688,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -2409,6 +1705,11 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ=="
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -2424,12 +1725,12 @@
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -2480,14 +1781,14 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha1-2m0NVpLvtGHggsFIF/4kJ9j10FQ="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -2509,7 +1810,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "escodegen": {
       "version": "1.8.1",
@@ -2527,6 +1828,15 @@
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A=="
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
     },
@@ -2567,7 +1877,7 @@
     "eventsource": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+      "integrity": "sha512-bbB5tEuvC+SuRUG64X8ghvjgiRniuA4WlehWbFnoN4z6TxDXpyX+BMHF7rMgZAqoe+EbyNRUbHN0uuP9phy5jQ==",
       "requires": {
         "original": ">=0.0.5"
       }
@@ -2614,6 +1924,15 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
           "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "optional": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -2681,11 +2000,6 @@
             "toidentifier": "1.0.1"
           }
         },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
         "on-finished": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2701,11 +2015,6 @@
           "requires": {
             "side-channel": "^1.0.4"
           }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "setprototypeof": {
           "version": "1.2.0",
@@ -2741,9 +2050,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -2756,9 +2065,9 @@
       "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ=="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.3.2",
@@ -2774,9 +2083,9 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2866,7 +2175,7 @@
     "flowdock": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/flowdock/-/flowdock-0.9.1.tgz",
-      "integrity": "sha1-R0cMDfxpqVU3S21kRHPlD+djpng=",
+      "integrity": "sha512-LfV+jSycydZzfgKsnoLvAg4bQgsazctECUb+O/qr4LYtCjy0Ep4cZ5JIkBSR4qlB0yx5889tLkSh5csgQ4So9w==",
       "requires": {
         "buffer-indexof": "^1.0.0",
         "request": "~2.58.0"
@@ -2875,56 +2184,40 @@
         "asn1": {
           "version": "0.1.11",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+          "integrity": "sha512-Fh9zh3G2mZ8qM/kwsiKwL2U2FmXxVsboP4x1mXjnhKHv3SmzaBZoYvxEQJz/YS2gnCgd8xlAVWcZnQyC9qZBsA=="
         },
         "assert-plus": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+          "integrity": "sha512-brU24g7ryhRwGCI2y+1dGQmQXiZF7TtIj583S96y0jjdajIe6wn8BuXyELYhvD22dtIxDQVFk04YTJwwdwOYJw=="
         },
         "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "^4.17.14"
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
+          "integrity": "sha512-oqUX0DM5j7aPWPCnpWebiyNIj2wiNI87ZxnOMoGv0aE4TGlBy2N+5iWc6dQ/NOKZaBD2W6PVz8jtOGkWzSC5EA=="
         },
         "caseless": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
-          "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk="
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.x.x"
-          }
+          "integrity": "sha512-1meZDjkziCX2rIL72FnjndyP96yCOfKhkmzr8Umi0xOw493PlVoOgfOmjScp9YaFJU1Acpwe9zeHBMVH5p4xPA=="
         },
         "extend": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
-          "integrity": "sha1-G3SYVAAXG4VVSJRFnJeN5u9FOrc="
+          "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
         },
         "form-data": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha512-M4Yhq2mLogpCtpUmfopFlTTuIe6mSCTgKvnlMhDj3NcgVhA1uS20jT0n+xunKPzpmL5w2erSVtp+SKiJf1TlWg==",
           "requires": {
             "async": "^2.0.1",
             "combined-stream": "^1.0.5",
@@ -2932,19 +2225,19 @@
           },
           "dependencies": {
             "mime-types": {
-              "version": "2.1.21",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-              "integrity": "sha1-KJlaoey3cHQv5q5+WPkYHHRLP5Y=",
+              "version": "2.1.35",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+              "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
               "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "1.52.0"
               }
             }
           }
         },
         "har-validator": {
           "version": "1.8.0",
-          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "integrity": "sha512-0+M2lRG5aXVEFwZZ2tUeRVBZT5AxViug9y94qquvQaHHVoL9ydL86aJvI3K28rwoD+DL15DzAgWtPCXNhdTKAQ==",
           "requires": {
             "bluebird": "^2.9.30",
             "chalk": "^1.0.0",
@@ -2952,61 +2245,50 @@
             "is-my-json-valid": "^2.12.0"
           }
         },
-        "hawk": {
-          "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
         "http-signature": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-          "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
+          "integrity": "sha512-Cg0qO4VID3bADaSsfFIh4X0UqktZKlKWM4tRpa2836Xka0U11xGMnX1AQBPyEkzTLc1KDqiQ8UmNB2qRYHe3SQ==",
           "requires": {
             "asn1": "0.1.11",
             "assert-plus": "^0.1.5",
             "ctype": "0.5.3"
           }
         },
-        "mime-db": {
-          "version": "1.37.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-          "integrity": "sha1-C2oM5v2+lXbiXx8tL96IMNwK0Ng="
-        },
         "mime-types": {
           "version": "2.0.14",
-          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha512-2ZHUEstNkIf2oTWgtODr6X0Cc4Ns/RN/hktdozndiEhhAC2wxXejF1FH0XLHTEImE9h6gr/tcnr3YOnSGsxc7Q==",
           "requires": {
             "mime-db": "~1.12.0"
           },
           "dependencies": {
             "mime-db": {
               "version": "1.12.0",
-              "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-              "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+              "integrity": "sha512-5aMAW7I4jZoZB27fXRuekqc4DVvJ7+hM8UcWrNj2mqibE54gXgPSonBYBdQW5hyaVNGmiYjY0ZMqn9fBefWYvA=="
             }
           }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA=="
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha512-VlF07iu3VV3+BTXj43Nmp6Irt/G7j/NgEctUS6IweH1RGhURjjCc2NWtzXFPXXWWfc7hgbXQdtiQu2LGp6MxUg=="
         },
         "qs": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-          "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw="
+          "integrity": "sha512-nR5uYqNsm8CgBhfCpsYKz6iDhvKjf0xdFT4KanNlLP40COGwZEsjbLoDyL9VrTXyiICUGUbsiN3gBpLGZhSZWQ=="
         },
         "request": {
           "version": "2.58.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.58.0.tgz",
-          "integrity": "sha1-tfScC5Sqt/rTiGEqH7atA7bMFYA=",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
+          "integrity": "sha512-okf2uk5kTQKSr+xClLCKA6jGH+ekhV1TfzS7eGiR0u2+ozO2uOSwFUlBZ8xx7C8Oula36UfTaYGxqs4VRpaPRw==",
           "requires": {
             "aws-sign2": "~0.5.0",
             "bl": "~0.9.0",
@@ -3029,38 +2311,30 @@
             "tunnel-agent": "~0.4.0"
           }
         },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
         "tunnel-agent": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+          "integrity": "sha512-e0IoVDWx8SDHc/hwFTqJDQ7CCDTEeGhmcT9jkWJjoGQSpgBz20nAMr80E3Tpk7PatJ1b37DQDgJR3CNSzcMOZQ=="
         }
       }
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
     },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -3089,7 +2363,7 @@
     "fs-jetpack": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-0.13.3.tgz",
-      "integrity": "sha1-nmxHEY8Ls9iAzIj5+KfSWGP0+xU=",
+      "integrity": "sha512-PeSnC/SG2dnXPbV9wefudQSdGpVPCf+Vh1XidOlEXyYFgJ+UeWkWkG7GH8pUgs1VxRK1OeJ6dXzX6KQTM+ZE5w==",
       "requires": {
         "minimatch": "^3.0.2"
       }
@@ -3102,7 +2376,7 @@
     "generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "requires": {
         "is-property": "^1.0.2"
       }
@@ -3110,7 +2384,7 @@
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "requires": {
         "is-property": "^1.0.0"
       }
@@ -3129,7 +2403,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3182,11 +2456,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -3226,21 +2495,21 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -3278,20 +2547,20 @@
       }
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "integrity": "sha512-Pnn5Bomr1ypnBHCwhsnj+5zhP3nel9ZPa9wdzFoanaN5+1/g5dtDfBZVVZR112sfYiAftUTFczmiWGkuG0SkSQ==",
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ=="
     },
     "http-errors": {
       "version": "1.7.3",
@@ -3303,24 +2572,17 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        }
       }
     },
     "http-parser-js": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.6.tgz",
-      "integrity": "sha1-GVJz9YcExFLWcQdr4gEyndNB3FU="
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -3328,26 +2590,26 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
+        "agent-base": "6",
+        "debug": "4"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -3390,12 +2652,12 @@
     "hubot-diagnostics": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/hubot-diagnostics/-/hubot-diagnostics-0.0.2.tgz",
-      "integrity": "sha1-oEKyzcn9jwFYPhBWWBMKbYua84Y="
+      "integrity": "sha512-q0Tokqy1XZ9XMBRuNpXK3nROFn7oiiCD+9bjMwco8k7Ny3M0SlnzVnGwTDztMgln6C3IG+26h4fKCAhGPQZL5A=="
     },
     "hubot-flowdock": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/hubot-flowdock/-/hubot-flowdock-0.7.8.tgz",
-      "integrity": "sha1-gQHVQsujI+yENwEuEPKFNpYO+dk=",
+      "integrity": "sha512-YIr+qG3qKIhsX5Lj2mI/YRy0P403oka7FkkRsAaFbkM8n4w+rYuZRizPYw7hE7VVbjJ+/awYCh9/DZ+ZQ6nv/g==",
       "requires": {
         "flowdock": "^0.9.1",
         "parent-require": "^1.0.0"
@@ -3404,7 +2666,7 @@
     "hubot-help": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/hubot-help/-/hubot-help-0.2.2.tgz",
-      "integrity": "sha1-zqF+eCzndrdD9lOTk1s0MMLoGXw="
+      "integrity": "sha512-GYEHWl+3/BV5PRI3TcmHdCa3YcmPXuUMWgnrVn4gpdRNKOqyVu2zrF7DtDn7dICuogILUDjQusN9KHjaT3TOWg=="
     },
     "hubot-irc": {
       "version": "0.4.2",
@@ -3426,44 +2688,15 @@
     "hubot-redis-brain": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/hubot-redis-brain/-/hubot-redis-brain-0.0.4.tgz",
-      "integrity": "sha1-kYLFd1YAZbNKBaLqHdq6Ix0JMCM=",
+      "integrity": "sha512-E8gW2WI6El+LB/tstf6LaCveMkn15KJrgl2jONdR6ehE4Mzw1PzYzBWdA4pte1mmM2LHW/CyxlH8yXO08thiRA==",
       "requires": {
         "redis": "~2.6.x"
-      },
-      "dependencies": {
-        "redis": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
-          "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
-          "requires": {
-            "double-ended-queue": "^2.1.0-0",
-            "redis-commands": "^1.2.0",
-            "redis-parser": "^2.0.0"
-          },
-          "dependencies": {
-            "double-ended-queue": {
-              "version": "2.1.0-0",
-              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
-            },
-            "redis-commands": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-              "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
-            },
-            "redis-parser": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-              "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
-            }
-          }
-        }
       }
     },
     "hubot-rocketchat": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hubot-rocketchat/-/hubot-rocketchat-2.0.0.tgz",
-      "integrity": "sha1-0a3p8ULBseB9/SeIgAUTP5ajOqU=",
+      "integrity": "sha512-p6vThyU9iLwy2o5vY6yJg4KZrOHVCtxJp/ZCAcWVs1NV/+VEwvtvrWf4Z+G8Xcxgxuxked0wpue7oRVTk6RbZw==",
       "requires": {
         "@rocket.chat/sdk": "^0.1.0",
         "hubot": "3"
@@ -3472,7 +2705,7 @@
     "hubot-scripts": {
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/hubot-scripts/-/hubot-scripts-2.17.2.tgz",
-      "integrity": "sha1-mwjpB9XPq6cteDIEBnp4zp3zriQ=",
+      "integrity": "sha512-OP3sVSuYUZEjcJZfT0dh1YVkg/lPiPUV5InhY2b22Sr69L7qZdheZ7KT6YCghGmBKeUcMjVSb/O0Iqnio7H7Sg==",
       "requires": {
         "redis": "0.8.4"
       },
@@ -3480,7 +2713,7 @@
         "redis": {
           "version": "0.8.4",
           "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.4.tgz",
-          "integrity": "sha1-FGCfJkFOIRwx480H3HmwS/n/GYA="
+          "integrity": "sha512-qCA0YGVb1C3HCuCv6FO4NAiIK/k5wG6JIMBdixJxcQf9wLGjV4eF8K50r5lwy49lTi8PH/q9aqQ5RsV7patQzQ=="
         }
       }
     },
@@ -3577,9 +2810,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -3623,7 +2856,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -3646,19 +2879,19 @@
       }
     },
     "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg=="
     },
     "is-my-json-valid": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha1-j9bkA2PNBrlj+od9REv7Xt3GIXU=",
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
         "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
+        "jsonpointer": "^5.0.0",
         "xtend": "^4.0.0"
       }
     },
@@ -3684,7 +2917,7 @@
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3694,12 +2927,12 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -3732,7 +2965,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "istanbul": {
       "version": "0.4.5",
@@ -3798,8 +3031,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "json-schema": {
       "version": "0.4.0",
@@ -3807,14 +3039,14 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -3827,9 +3059,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -3846,13 +3078,6 @@
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
         "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
       }
     },
     "jsprim": {
@@ -4076,8 +3301,8 @@
     },
     "log": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/log/-/log-1.4.0.tgz",
-      "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
+      "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
+      "integrity": "sha512-NnLhcxIAbhdhuMU0jDG83YjAH8JQj8tXUTy54Ib+4owuXwerrYFI8+OsnK1Ez/cig8O859QK6u6g0aYph/X/zQ=="
     },
     "long": {
       "version": "5.2.3",
@@ -4094,9 +3319,9 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -4108,13 +3333,6 @@
       "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
       "requires": {
         "inherits": "^2.0.4"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        }
       }
     },
     "mattermost-client": {
@@ -4131,71 +3349,6 @@
         "ws": ">=3.3.1"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "aws4": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
         "log": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
@@ -4209,91 +3362,17 @@
             "type": "^2.5.0",
             "uni-global": "^1.0.0"
           }
-        },
-        "mime-db": {
-          "version": "1.52.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-          "version": "2.1.35",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-          "requires": {
-            "mime-db": "1.52.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
-        "punycode": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-        },
-        "request": {
-          "version": "2.88.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "ws": {
-          "version": "8.14.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
         }
       }
     },
     "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "media-typer": {
@@ -4333,16 +3412,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.52.0"
       }
     },
     "min-document": {
@@ -4380,9 +3459,9 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "ms-rest": {
       "version": "2.5.6",
@@ -4412,30 +3491,6 @@
             "uri-js": "^4.2.2"
           }
         },
-        "aws4": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
-        },
         "http-signature": {
           "version": "1.3.6",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
@@ -4446,11 +3501,6 @@
             "sshpk": "^1.14.1"
           }
         },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
         "jsprim": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
@@ -4460,93 +3510,6 @@
             "extsprintf": "1.3.0",
             "json-schema": "0.4.0",
             "verror": "1.10.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.52.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-          "version": "2.1.35",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-          "requires": {
-            "mime-db": "1.52.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
-        "punycode": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-        },
-        "request": {
-          "version": "2.88.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "http-signature": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-              "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              }
-            },
-            "jsprim": {
-              "version": "1.4.2",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-              "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-              }
-            },
-            "uuid": {
-              "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-            }
-          }
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
           }
         }
       }
@@ -4577,16 +3540,6 @@
             "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.1"
           }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "setprototypeof": {
           "version": "1.2.0",
@@ -4641,11 +3594,6 @@
         "uuid": "^9.0.0"
       },
       "dependencies": {
-        "es6-promise": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-        },
         "uuid": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -4693,11 +3641,6 @@
           "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
         }
       }
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "node-xmpp-client": {
       "version": "3.0.0",
@@ -4751,9 +3694,9 @@
       }
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-inspect": {
       "version": "1.13.1",
@@ -4768,7 +3711,7 @@
     "object.assign": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-1.1.1.tgz",
-      "integrity": "sha1-8ilnQnP5T8sjDQLBlYqLlOye+Vw=",
+      "integrity": "sha512-F69Cy1YWq1KjNDhAhT4vpC5/8MVw5r2IsZC1PrlOVt/d8VtxJC/m9vFrhZwizNKlLfjA61bIpWhHpjHXbBdF0Q==",
       "requires": {
         "object-keys": "~1.0.1"
       }
@@ -4805,7 +3748,7 @@
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+      "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg=="
     },
     "optparse": {
       "version": "1.0.5",
@@ -4846,7 +3789,7 @@
     "parent-require": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
-      "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
+      "integrity": "sha512-2MXDNZC4aXdkkap+rBBMv0lUsfJqvX5/2FiYYnfCnorZt3Pk06/IOR5KeaoghgS2w07MLWgjbsnyaq6PdHn2LQ=="
     },
     "parse-headers": {
       "version": "2.0.5",
@@ -4882,7 +3825,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -4952,7 +3895,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "psl": {
       "version": "1.9.0",
@@ -4960,9 +3903,9 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "pvtsutils": {
       "version": "1.3.5",
@@ -4980,12 +3923,12 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
     },
     "querystringify": {
       "version": "2.2.0",
@@ -5036,11 +3979,6 @@
             "toidentifier": "1.0.1"
           }
         },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
         "setprototypeof": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -5069,8 +4007,8 @@
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -5096,11 +4034,6 @@
             "util-deprecate": "^1.0.1"
           }
         },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
         "string_decoder": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5125,44 +4058,74 @@
         }
       }
     },
+    "redis": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
+      "integrity": "sha512-u5pJPYdQX5Oca+nyThh0CJD0fSRyj0Z9ldn9LIEenNdiMZJ5Ut90q12St8ICYLvDsfbLqF0MujyU0c3ZLA06CA==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha512-9Hdw19gwXFBJdN8ENUoNVJFRyMDFrE/ZBClPicKYDPwNPJ4ST1TedAHYNSiGKElwh2vrmRGMoJYbVdJd+WQXIw=="
+    },
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha1-WgNhWkfGFCCz65m326IE+DYD4fo=",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
       "version": "1.1.7",
@@ -5217,9 +4180,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -5277,16 +4240,6 @@
             "statuses": "2.0.1",
             "toidentifier": "1.0.1"
           }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "on-finished": {
           "version": "2.4.1",
@@ -5368,21 +4321,17 @@
       }
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha512-7bgVOAnPj3XjrKY577S+puCKGCRlUrcrEdsMeRXlg9Ghf5df/xNi6sONUa43WrHUd3TjJBF7O04jYoiY0FVa0A==",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "2.x.x"
       }
     },
     "source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
-      "optional": true,
-      "requires": {
-        "amdefine": ">=0.0.4"
-      }
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
     },
     "sprintf-js": {
       "version": "1.1.3",
@@ -5398,9 +4347,9 @@
       }
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -5409,6 +4358,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
@@ -5441,17 +4391,17 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -5466,13 +4416,9 @@
       }
     },
     "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "optional": true,
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
     },
     "text-encoding": {
       "version": "0.7.0",
@@ -5522,11 +4468,12 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "punycode": "^1.4.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "truncate": {
@@ -5552,7 +4499,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -5560,8 +4507,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "type": {
       "version": "2.7.2",
@@ -5583,21 +4529,6 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.52.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-          "version": "2.1.35",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-          "requires": {
-            "mime-db": "1.52.0"
-          }
-        }
       }
     },
     "typed-emitter": {
@@ -5625,7 +4556,7 @@
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+      "integrity": "sha512-QMpnpVtYaWEeY+MwKDN/UdKlE/LsFZXM5lO1u7GaZzNgmIbGixHEmVMIKT+vqYOALu3m5GYQy9kz4Xu4IVn7Ow=="
     },
     "uni-global": {
       "version": "1.0.0",
@@ -5652,19 +4583,12 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-        }
       }
     },
     "url-join": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha512-zz1wZk4Lb5PTVwZ3HWDmm8XnlPvmOof6/fjdDPA5yBrUcbtV64U6bV832Zf1BtU2WkBBWaUT46wCs+l0HP5nhg=="
     },
     "url-parse": {
       "version": "1.5.10",
@@ -5699,9 +4623,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "valid-url": {
       "version": "1.0.9",
@@ -5791,11 +4715,12 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
       "requires": {
-        "http-parser-js": ">=0.4.0",
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
@@ -5813,11 +4738,11 @@
       }
     },
     "winston": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.6.tgz",
-      "integrity": "sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
+      "integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
       "requires": {
-        "async": "^3.2.3",
+        "async": "^2.6.4",
         "colors": "1.0.x",
         "cycle": "1.0.x",
         "eyes": "0.1.x",
@@ -5826,9 +4751,12 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
         }
       }
     },
@@ -5848,23 +4776,19 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha1-y9nm514J/F0skAFfIfDECHXg3VE=",
-      "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
-      }
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1431,7 +1431,6 @@
         "promise": "^7.1.1",
         "request": "^2.88.0",
         "rsa-pem-from-mod-exp": "^0.8.4",
-        "skills-validator": "file:node_modules/botbuilder/skills-validator/skills-validator-1.0.0.tgz",
         "sprintf-js": "^1.0.3",
         "url-join": "^1.1.0"
       },
@@ -4971,15 +4970,6 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
-      }
-    },
-    "skills-validator": {
-      "version": "file:node_modules/botbuilder/skills-validator/skills-validator-1.0.0.tgz",
-      "integrity": "sha512-UFmS/Tj/1LcrwWkL8jqStUeKRHp3G5Ee2FmRJzerSOJIjSlTXePvvqTpKSxb1iXnZz7+BPayXAaSIMCfvKWcFQ==",
-      "requires": {
-        "@types/node-fetch": "^2.5.4",
-        "adal-node": "^0.2.1",
-        "node-fetch": "^2.6.0"
       }
     },
     "sntp": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,31 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "@babel/runtime-corejs2": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.23.4.tgz",
-      "integrity": "sha512-w10wlnER4ZJ60UlxQWiDhaD1nxHrJ3YgGK2V5iws7a07Q1+vQw4eL54kdtuPIadE3LkeG/Xtg+TEI5zWgjYEjw==",
-      "requires": {
-        "core-js": "^2.6.12",
-        "regenerator-runtime": "^0.14.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-        }
-      }
-    },
     "@danielkalen/source-map-support": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@danielkalen/source-map-support/-/source-map-support-0.4.16.tgz",
@@ -42,32 +17,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
-      }
-    },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "optional": true,
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "optional": true
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "optional": true,
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
       }
     },
     "@peculiar/asn1-schema": {
@@ -148,11 +97,6 @@
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
         }
       }
-    },
-    "@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@types/async": {
       "version": "2.4.2",
@@ -244,6 +188,35 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.36.tgz",
       "integrity": "sha1-xKK9sW06ebNOAUZLS9OMG4Se/aw="
     },
+    "@types/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/qs": {
       "version": "6.9.10",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
@@ -311,111 +284,82 @@
       "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.6.tgz",
       "integrity": "sha512-7ynfYbbQHV3iz7K77wzgVoBBisyoMuFhLSoIhs1dl49WPzMZ0ybVqUq6Opa6n+0vBaWDXmzNbBkeNzsmPFWDJA=="
     },
-    "@unimodules/core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@unimodules/core/-/core-7.1.2.tgz",
-      "integrity": "sha512-lY+e2TAFuebD3vshHMIRqru3X4+k7Xkba4Wa7QsDBd+ex4c4N2dHAO61E2SrGD9+TRBD8w/o7mzK6ljbqRnbyg==",
-      "optional": true,
-      "requires": {
-        "compare-versions": "^3.4.0"
-      }
-    },
-    "@unimodules/react-native-adapter": {
-      "version": "6.3.9",
-      "resolved": "https://registry.npmjs.org/@unimodules/react-native-adapter/-/react-native-adapter-6.3.9.tgz",
-      "integrity": "sha512-i9/9Si4AQ8awls+YGAKkByFbeAsOPgUNeLoYeh2SQ3ddjxJ5ZJDtq/I74clDnpDcn8zS9pYlcDJ9fgVJa39Glw==",
-      "optional": true,
-      "requires": {
-        "expo-modules-autolinking": "^0.0.3",
-        "invariant": "^2.2.4"
-      }
-    },
     "@webex/common": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.161.0.tgz",
-      "integrity": "sha512-gY0IK2yeNv10b6AYrXa5FAicDvYd91jkY4Mf/L1UosuOLHA8UEVRNIQxMDPSdoaHUXBk+WI6rti1d/XnQFz8QQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.80.178.tgz",
+      "integrity": "sha512-UMZSSUxomcvnFvOt3/IiNMBDLGeLMPR62u/9ZJ6R0qUPsIIJpO9yBI+6N04fJS4hvTBinDMeD66ql42hATRmiQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
+        "@webex/common": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "backoff": "^2.5.0",
-        "bowser": "^2.11.0",
         "core-decorators": "^0.20.0",
         "envify": "^4.1.0",
-        "global": "^4.4.0",
-        "lodash": "^4.17.21",
-        "safe-buffer": "^5.2.0",
+        "lodash": "^4.17.15",
         "urlsafe-base64": "^1.0.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
       }
     },
     "@webex/common-timers": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.161.0.tgz",
-      "integrity": "sha512-30oeHYvnhfP79KRw5+tDbzOkqXslPy4xjcQMYDWTsg/xvUeSaX9Wf7Odumnkspee4SNuqcqYTCKP7Pc8ZCSVHg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.80.178.tgz",
+      "integrity": "sha512-BJUWfDtqareL6HJbLjTk2dmiuGqwtDGHQF50YFKkz6ck2ZapmJZSsox3q3tsImLavYfrF0ltQYnRCLOx0q4mww==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
         "envify": "^4.1.0"
       }
     },
     "@webex/helper-html": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.161.0.tgz",
-      "integrity": "sha512-kQ7UX2X4Oo5R3W42ATIHr/Mb/VpJO+FNRtHQaPFs5vmLUT4Zy4hJ7AHn1Mo7FkOIn40eAe5ezSs/x+ifsal/aw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.80.178.tgz",
+      "integrity": "sha512-08pTVqvvNvXRsqvtSHz34At8Y6eMBGs5P1byvYdl6CE80LIfng69+cNFPzQTLKvRFmP+o3GZc9Uj8Yc1GINaWQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       }
     },
     "@webex/helper-image": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.161.0.tgz",
-      "integrity": "sha512-KdkVqS7D0hoDKCTFDcVMmDy7UhAEynitTkXlwHYJFigiq5Lq0R/YHdk7DiziHMABMxfrq6vl9mhUakzXjhQCAg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.80.178.tgz",
+      "integrity": "sha512-LwnqJCP7/yank0dVM5qiq9K1ALFPgHl68Z9AfObNSorNC8PljdcG/hsowNkM9rj/s0rv9+eB53hbL0g68FIzJA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/http-core": "1.161.0",
+        "@webex/http-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "exifr": "^5.0.3",
+        "exif": "^0.6.0",
         "gm": "^1.23.1",
-        "lodash": "^4.17.21",
-        "mime": "^2.4.4",
-        "safe-buffer": "^5.2.0"
+        "lodash": "^4.17.15",
+        "mime-types": "^2.1.24"
       },
       "dependencies": {
-        "mime": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+        "mime-db": {
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        "mime-types": {
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+          "requires": {
+            "mime-db": "1.52.0"
+          }
         }
       }
     },
     "@webex/http-core": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.161.0.tgz",
-      "integrity": "sha512-2JCvZ1lJwwv2Ajn9cn7QrbD6QbMR1p9pXu2JcjhYP2WdHssT6pBvNMZ009uJ1JRGexY3QQKuBNlzn8M87xbQtw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.80.178.tgz",
+      "integrity": "sha512-iBaHvEaX9KdMaB4mUM+dpyM56qWOplI4GFDVAxYmf8SLZMiiQwjCC6gu/TLMTBcg4vPiQwO/9tHVPCkk//vNFA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
+        "@webex/common": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "file-type": "^16.0.1",
+        "file-type": "^3.9.0",
         "global": "^4.4.0",
         "is-function": "^1.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "parse-headers": "^2.0.2",
         "qs": "^6.7.0",
         "request": "^2.88.0",
-        "safe-buffer": "^5.2.0",
         "xtend": "^4.0.2"
       },
       "dependencies": {
@@ -524,11 +468,6 @@
             }
           }
         },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -551,36 +490,36 @@
       }
     },
     "@webex/internal-plugin-calendar": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.161.0.tgz",
-      "integrity": "sha512-tbw50C4rW6MAWpu8rD1wQyivmDjR6lA6dSYwddy2jNNvmmq0lOkR0CQjry2KTxbzpFQzptXEMmpXbMZFCRCLKw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.80.178.tgz",
+      "integrity": "sha512-kl4MUC5crbKPEAbQKa6ELc/26CkQXQMBOlHcUKgvBNXkUl7YlM6ezWfBRnZr1AAYNGMW9Ezzd+TvL1iojg5n2Q==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-encryption": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-encryption": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "btoa": "^1.2.1",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-conversation": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.161.0.tgz",
-      "integrity": "sha512-1/yud5FtF7QXHJn+NspdDaBF5ecQmnoafX+8LiZhnOSO8/eCuWPkBqzxTc7hvnI0+oluontZHKR2ZN6wrREn1Q==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.80.178.tgz",
+      "integrity": "sha512-yB+3KCHMAi0YN/sDbaN0NeC/NzNe8Em5AaLID+9CqGE5G/94QTW4O2YssyqJJ2CvDhLlhXS5B0HsqbJGAKgQMA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/helper-html": "1.161.0",
-        "@webex/helper-image": "1.161.0",
-        "@webex/internal-plugin-encryption": "1.161.0",
-        "@webex/internal-plugin-user": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "crypto-js": "^4.1.1",
+        "@webex/common": "1.80.178",
+        "@webex/helper-html": "1.80.178",
+        "@webex/helper-image": "1.80.178",
+        "@webex/internal-plugin-encryption": "1.80.178",
+        "@webex/internal-plugin-user": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "crypto-js": "^3.1.9-1",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21",
-        "node-scr": "^0.3.0",
+        "lodash": "^4.17.15",
+        "node-scr": "^0.2.2",
         "uuid": "^3.3.2"
       },
       "dependencies": {
@@ -592,44 +531,42 @@
       }
     },
     "@webex/internal-plugin-device": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-1.161.0.tgz",
-      "integrity": "sha512-y8MV6gmHdC/5WijCPrTXNmQGRSqt4WADNT4CzdyYBtAkybOHRJRineE2IqhH72MRYkh/+aDBjW2mvbGhMUkwWg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-1.80.178.tgz",
+      "integrity": "sha512-1QJ+cy2OKOzKpFMEj0Qq51/e2vWFhpoqxpcClGZ+D3tt5H/xHa1GHtgdWXSalfF/PKJl6TSnR0sgD/p3MoQcBQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/http-core": "1.161.0",
-        "@webex/internal-plugin-metrics": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/http-core": "1.80.178",
+        "@webex/webex-core": "1.80.178",
         "ampersand-collection": "^2.0.2",
         "ampersand-state": "^5.0.3",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-encryption": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.161.0.tgz",
-      "integrity": "sha512-Fgq4UyHLmKhfwWQBBLhK+Krz0UIB/cu3nwPnNr2EvUb7ZeoxPcd+jnMEHp+QDEUMa41Vr59pYPPBxvhtv1CLqg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.80.178.tgz",
+      "integrity": "sha512-R2AJh/cA/g3vIgYmbkqOxE/Z/Trj1cl640Ldshj7wwT7cX/KTmLD3dChP4uyV0X316v5EofZRwLyMSi4qX/Ysw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/http-core": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@peculiar/webcrypto": "^1.0.22",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/http-core": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
         "asn1js": "^2.0.26",
+        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "isomorphic-webcrypto": "^2.3.8",
-        "lodash": "^4.17.21",
-        "node-jose": "^2.0.0",
-        "node-kms": "^0.4.0",
-        "node-scr": "^0.3.0",
+        "lodash": "^4.17.15",
+        "node-jose": "^0.11.1",
+        "node-kms": "^0.3.2",
+        "node-scr": "^0.2.2",
         "pkijs": "^2.1.84",
-        "safe-buffer": "^5.2.0",
         "valid-url": "^1.0.9"
       },
       "dependencies": {
@@ -645,59 +582,54 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "@webex/internal-plugin-feature": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.161.0.tgz",
-      "integrity": "sha512-sKuICbBHWx7Fi60EsdLe0H4preh8XT+I464TJ01bE2EDEldEbl1viFrAE1TOAlkXokWb2+xKEH4c/9hFQqB4VA==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.80.178.tgz",
+      "integrity": "sha512-2UJgZu8F5x0MaLSS5StOLOIEpirYy80uqCRxyTvuqk/6/bJe9dw01kCXZtVT1xC0bya4Z2bjzhzqGkcDaOMF+A==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-lyra": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.161.0.tgz",
-      "integrity": "sha512-B50bsDVdvJBNP56j0RbLxlbByIr/CRpRzBTKfGzV6zQoXUYs99inLTCkMc3Q4NwRCISaeBzcO5wFadJG8H62Xg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.80.178.tgz",
+      "integrity": "sha512-023/09xkyc6O8PV3L49dWnxt5HDO5yW4RFhc5zpNwZI6MG+Jpuj9PXgJ6uZ4NJbIMD4T59zcNioPE5f9lj82/A==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-encryption": "1.161.0",
-        "@webex/internal-plugin-feature": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-encryption": "1.80.178",
+        "@webex/internal-plugin-feature": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-mercury": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.161.0.tgz",
-      "integrity": "sha512-wm9STxbSDNj/1iW198LWk7F5M5AgUI1+yonSSUDOvc8QmxRuk7fuk1fZ0VrqNAR7uEkO56gEmnG+91pJTt71eA==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.80.178.tgz",
+      "integrity": "sha512-oKlOIwqTMkkC4C9q6fQ1XTSbL0a0IvO0lrMvr/jF4gLWrg5EszXjuvft+qWB4N5z3hmHGvubrQyUNuqvBhWvaw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-feature": "1.161.0",
-        "@webex/internal-plugin-metrics": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-feature": "1.80.178",
+        "@webex/internal-plugin-metrics": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "backoff": "^2.5.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "uuid": "^3.3.2",
-        "ws": "^8.2.2"
+        "ws": "^4.1.0"
       },
       "dependencies": {
         "uuid": {
@@ -706,97 +638,81 @@
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "ws": {
-          "version": "8.14.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
     "@webex/internal-plugin-metrics": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.161.0.tgz",
-      "integrity": "sha512-B/OJhvZlUNBRhPck1IIxJRAg7eTTtry6+/K+wmjLwtfH1FF9HgSOFu0i7cQiyfql/rzLrs4QaG/6PpqiGl+cuQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.80.178.tgz",
+      "integrity": "sha512-gibR0AT/yvmWufCyBZA74THzDez80WTbO28jW+JKidlpcjf6+Gx6SrgQ+nl60I3zHf7v9TVOsHWMsytRQRWNmQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-presence": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.161.0.tgz",
-      "integrity": "sha512-ch8ojz267xyNlOjywHRTg0rKbBGyNZ4CkSTq1N0TaJ2ne0ZM9mZA+mTC2cQ/p4Fi3jQA3iE5FOQZERvxsY5ABw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.80.178.tgz",
+      "integrity": "sha512-/nJ72ttqLkdBOv8Z7wN1yWIPLyaPtJu3GDoshHwXEtvF51WzR5CHt51VhgmOu0g6spejBcYMJ5eNppozrnQqCQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-search": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.161.0.tgz",
-      "integrity": "sha512-9wWIPVNrvsOQ8WOjFsOqzT4s5PDvmJz+L+ZKREsyqLsH7RfO92dsjUnIKYhpYQj7TGaByVlmdOzLf//IjJ4N7Q==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.80.178.tgz",
+      "integrity": "sha512-zWojY1Iz2tF3yN9py5tg5d9dkyV8MetMMB01Mp5sCLGjInCEBhwbSMcHTOu2tigzr8pd61Y5EP5pvD7VOWP5Kg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-encryption": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-encryption": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "@webex/internal-plugin-support": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-support/-/internal-plugin-support-1.161.0.tgz",
-      "integrity": "sha512-ye7XQHXApxGnnbMkPRbN1QA2fFFIISvccsn20PJszdVX4GRohGSBhjQxfZlZSK2MaCrGsFR3FhB4/kspURXw6g==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.21",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
+        "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-user": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.161.0.tgz",
-      "integrity": "sha512-4NHMIi1+0trR5TjhduX5QTQ+8acNhlSJ64XE4nwxRIer0hADAlQXBLPA1IFf72PYG8l2WijQ0vy8tv07Wra50A==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.80.178.tgz",
+      "integrity": "sha512-KXKvxi34IsRXTBj6KTboSVVhLVe6yb43Ht2HPrGp1Yu8Qx8eptnBbKGEZpAJX1KoQEreQxbRnl6t8GnwRdo3Jw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       }
     },
     "@webex/plugin-attachment-actions": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.161.0.tgz",
-      "integrity": "sha512-TBtdHUrkv2i6+ABrLvKZv9VLDEGb/LoJ04xTygMMqKgTrRrsmoS62bj1a2AFYaxKbpQdGPTsuV7/6H4wB5Ikzg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.80.178.tgz",
+      "integrity": "sha512-jW/bq/TRbYaTQrZJdri1CWxIk+CCBgtsdj8Uf2utuBz9aT6jEto2jTZOo7w0G8IeIjCqk+yGoVWBGcCBHuc7Xw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -815,27 +731,26 @@
       }
     },
     "@webex/plugin-authorization": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.161.0.tgz",
-      "integrity": "sha512-0ZQfYd7Pdr846Guh1BYcSQJtS0woUQVvNebRXGhwr+YZPC4oYLMk5ISrY+1oocXrZbdJdfkka4ij53lhazYA/Q==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.80.178.tgz",
+      "integrity": "sha512-iVSAlJinBVGA48ZUKJW5lG0NSFgvfZwavFe4mD+BKF05NdvTlp9aXRe90evkOWT3VV97rc4PNqd8iqJelaWCPg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/plugin-authorization-browser": "1.161.0",
-        "@webex/plugin-authorization-node": "1.161.0",
+        "@webex/plugin-authorization-browser": "1.80.178",
+        "@webex/plugin-authorization-node": "1.80.178",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-authorization-browser": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.161.0.tgz",
-      "integrity": "sha512-MSipQ/IQ8fWTu3sDWmQoxN0yGXBwwG3cPt9M+tE4QMmzkF+PjBSGTCmIzLy147U24h5d9wQGGJBWSn8tQwbM1Q==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.80.178.tgz",
+      "integrity": "sha512-Z9J+MAQ+29eGEINL1hZv4PwxkyxW3AccAsHxvCmO/h8y/3Cu0x8jQ3xIos7vmmLU5dtqIv0XDktnDmd30/xeNw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "uuid": "^3.3.2"
       },
       "dependencies": {
@@ -847,29 +762,29 @@
       }
     },
     "@webex/plugin-authorization-node": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.161.0.tgz",
-      "integrity": "sha512-oYYHjEv/cVt+ZAbos1En4zA7+GtsxabwR0ZnjaHctSSxfpHoemzO68LJXvqJQRIbVl9do6GNizic4PN5KabhfQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.80.178.tgz",
+      "integrity": "sha512-8mAsOKfiPfYSXiAIroxE/GspZMtw0jcm6Rk+ENJhWrXSgQf5XgPrRR/y3uIpZ7PNeboUNObRKkx5vjkwHgbMBQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-device-manager": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.161.0.tgz",
-      "integrity": "sha512-xzIHP0llGJojMeuoMEtgnDPYpbj/HDMprGVMV/AGyCAuOEdY6mORNgbdavXX/YFVPJL6awBb7G6NXd77Aowujg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.80.178.tgz",
+      "integrity": "sha512-AiXCrLl7r2EsJ+SrZYpJKU4MDECVQoSCHR8nJ8V5yGtklKntiHFpj5P6BFOhI6+l6kU3zaCEOhbtQJ0QS37KaA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-lyra": "1.161.0",
-        "@webex/internal-plugin-search": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-lyra": "1.80.178",
+        "@webex/internal-plugin-search": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "uuid": "^3.3.2"
       },
       "dependencies": {
@@ -881,64 +796,37 @@
       }
     },
     "@webex/plugin-logger": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.161.0.tgz",
-      "integrity": "sha512-+JHz2Qgm7pHq2Syfv457N0rQPiSivVFqiq3V+KQ1iAUJiDbz3DlUTIGR90njtrcGDdNwHqqwbZonJ6KZUcOotQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.80.178.tgz",
+      "integrity": "sha512-maEaqtjemF+G5fI3/+E4YkpBqPhXIdGXRE4kXaqj1uRG4wiksopYOAroQ0ILtsAo3yOvqXu6KIiwnRZ37Da8cA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       }
     },
     "@webex/plugin-meetings": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.161.0.tgz",
-      "integrity": "sha512-nAYh5ZWX+vGDoxLvUHL8/YdT29VsbHZGw/U2q216KDuvxwhDNWGOnHFp32Eudi1cX79phZSOPgjzwtJ4Xq9oYg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.80.178.tgz",
+      "integrity": "sha512-aYKtPkMNPqRDuViCsMtLo3mnoZGxvQiogF1ctB6cckatihQnta/Du8xkcr0fLMyBhwhFcX2F7mx0zCWnUZNpFg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "bowser": "^2.11.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "bowser": "1.9.4",
         "btoa": "^1.2.1",
         "envify": "^4.1.0",
         "global": "^4.4.0",
-        "ip-anonymize": "^0.1.0",
         "javascript-state-machine": "^3.1.0",
-        "lodash": "^4.17.21",
-        "readable-stream": "^3.6.0",
+        "lodash": "^4.17.15",
         "sdp-transform": "^2.12.0",
-        "uuid": "^3.3.2",
-        "webrtc-adapter": "^7.7.0"
+        "uuid": "^3.3.2"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -947,18 +835,18 @@
       }
     },
     "@webex/plugin-memberships": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.161.0.tgz",
-      "integrity": "sha512-pjs7QAKu8E8QN3niULoZqQXkjfrD+Hqxe3S68ZstBPFvLIhmngP6SRPVQ0bKQIY1V25jGQ1fLigfjOnYjgBgMg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.80.178.tgz",
+      "integrity": "sha512-10YCfIuyj89GkBm2EClOafmedQVk9OkDNP5JLnaSDhgzbj/32geFkTApXMrKKaVr7EQLofpvZNtIPKFY+cuCfw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -977,43 +865,59 @@
       }
     },
     "@webex/plugin-messages": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.161.0.tgz",
-      "integrity": "sha512-vDTdYK0zulpK9J1+ucK3ZB+hGCA3lo0hKIscR0ScN33ideaiEDEFFBRqckmdeRammnyHHZ8Avi/kVYxfBbhtZg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.80.178.tgz",
+      "integrity": "sha512-OUOwR4u51p+Y2sGdIHLSIS33tNJFcUbkZJhT6Rnlu6xevJjwRALcUYJpVvkALNpiLos/j3OOfEc5hk7xCOJoOA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "@webex/plugin-people": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.161.0.tgz",
-      "integrity": "sha512-G6LbPPqgTht0pkorIJLpkChEnAo+R7u9q51KoPOLj1kM9LOqzOT6JA55z/WfzBZRwYITbfL7qV58FhyQ15sOgA==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.80.178.tgz",
+      "integrity": "sha512-bOaxiawzoPUdCrvFaxI9X+NlakOeXR2wv7rereBO2+QGU4tt7TheURhHGWCDggtcwYIqGJv2XipNdJhI4w0dTA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-rooms": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.161.0.tgz",
-      "integrity": "sha512-9amxryhzajJyyDFpLGa+YCBI4yvPoTgIj30dQZO0TniCbOYw/QM3BRzvtcn8+195V/ePQeR0RYcd9vqwtWy2iw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.80.178.tgz",
+      "integrity": "sha512-ttBOJcil8zJwisK+vAHupFDAtbDT/7BeLIDTaV3YVXn/iHk8jKTPyxu2HDCXlhQvApV8F9sBDrOxigEthqBCEw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -1032,63 +936,60 @@
       }
     },
     "@webex/plugin-team-memberships": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.161.0.tgz",
-      "integrity": "sha512-LIrp/hpd4RSl0gh97xl7xtopz0PSbeoUatO8u4XkBjUAZ6iPjYAyRuu68yXG7QxfCacePF+jdrdnOuhWsBMIVw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.80.178.tgz",
+      "integrity": "sha512-GsQutBpXmLd4yNdnqJPQYTtmoQaumVhdtk3QJ5P0XHH0NWOATvfr9DFg5H3zDsAGW15Bc3TJ8qXDQ7VaYJ1lLw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/webex-core": "1.161.0",
+        "@webex/webex-core": "1.80.178",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-teams": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.161.0.tgz",
-      "integrity": "sha512-IrZf33pY6FTStoBumxTSAAXSmzQ7Izia6ICPBi79J2MWrt81lm4MQP5OP+eg2Ub2U6kwrflIfTfYPNjG+OVJNQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.80.178.tgz",
+      "integrity": "sha512-Lo32lfa0549TkFeLXlfEDNd4N9k7DspxwEMpQUJzcKgmmuMI9uIQMlRt3uI2fAkQHL+D2AtK2pxsbY2iH2yzWQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/webex-core": "1.161.0",
+        "@webex/webex-core": "1.80.178",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-webhooks": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.161.0.tgz",
-      "integrity": "sha512-KA3rUC9ukfxyEiXwJdeZDxk+HDRtwkn5aE5ZAole7HxhidcY7Obvi+NJuSVSvp+W6giC0McFivoLP6UMwnPEww==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.80.178.tgz",
+      "integrity": "sha512-2yPnjMOLHZRUWjxS8uRZQR8Yh8sjqqF+tb/XmXTYwqd7RtLvuGOB1AmWzyUuv0IM2HGQBnViJB4sF84zLZKvZA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/webex-core": "1.161.0",
+        "@webex/webex-core": "1.80.178",
         "envify": "^4.1.0"
       }
     },
     "@webex/storage-adapter-local-storage": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.161.0.tgz",
-      "integrity": "sha512-Dzh/PQUbGeQ4h7Aq67QlS0uPZM/zldu8GZo8xjpZSGWDQx+t4ygcSXNgbVXLl9FrItZsxNAxBG2WTkNA5dBzIQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.80.178.tgz",
+      "integrity": "sha512-wLrhqchxXSL7O0iq8x7HA51H2RCHlRnPptpj+OV0DZt0mrx7phSO2FT2fY7ySyjUkN+QescJAb9QU37pFbn8ug==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/webex-core": "1.161.0",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/webex-core": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.161.0.tgz",
-      "integrity": "sha512-vmHdkZMXE+iUso1knXYnREOvm6NyUwLnSao+47xcqIvTKh+zOxl0VbvP+ovVLYux9xnqIyr6IQERDhJjKgml8w==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.80.178.tgz",
+      "integrity": "sha512-K8wVB4DCbbCfMz2mH5LG9farSS1LU8dV9vFyoGBSHt/N/Ori502QFmP+dA0lVg1zay3eQt/GHO3XNCI+Q+lnkw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/http-core": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/http-core": "1.80.178",
+        "@webex/webex-core": "1.80.178",
         "ampersand-collection": "^2.0.2",
         "ampersand-events": "^2.0.2",
         "ampersand-state": "^5.0.3",
+        "babel-runtime": "^6.26.0",
         "core-decorators": "^0.20.0",
-        "crypto-js": "^4.1.1",
+        "crypto-js": "^3.1.9-1",
         "envify": "^4.1.0",
         "jsonwebtoken": "^8.5.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "uuid": "^3.3.2"
       },
       "dependencies": {
@@ -1098,6 +999,11 @@
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
     },
     "abbrev": {
       "version": "1.0.9",
@@ -1124,6 +1030,31 @@
           "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
           "requires": {
             "mime-db": "1.52.0"
+          }
+        }
+      }
+    },
+    "adal-node": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.4.tgz",
+      "integrity": "sha512-zIcvbwQFKMUtKxxj8YMHeTT1o/TPXfVNsTXVgXD8sxwV6h4AFQgK77dRciGhuEF9/Sdm3UQPJVPc/6XxrccSeA==",
+      "requires": {
+        "@xmldom/xmldom": "^0.8.3",
+        "async": "^2.6.3",
+        "axios": "^0.21.1",
+        "date-utils": "*",
+        "jws": "3.x.x",
+        "underscore": ">= 1.3.1",
+        "uuid": "^3.1.0",
+        "xpath.js": "~1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "requires": {
+            "lodash": "^4.17.14"
           }
         }
       }
@@ -1257,11 +1188,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "asmcrypto.js": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-0.22.0.tgz",
-      "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
-    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -1294,16 +1220,15 @@
       "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "optional": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1323,20 +1248,35 @@
         "follow-redirects": "^1.14.0"
       }
     },
-    "b64-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
-      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
+    "b64u": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/b64u/-/b64u-2.0.0.tgz",
+      "integrity": "sha512-N3SnhKhQtwm9a4+rdNT0JvnNdPlRwpQZN4tfJwOE3/qJVzM+OlYj/Iz2n1S3KXAQmKHaRwWUNW5gEnjuD8cXHg=="
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==",
       "requires": {
-        "base-64": "^0.1.0"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w=="
+        }
       }
     },
-    "b64u-lite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/b64u-lite/-/b64u-lite-1.1.0.tgz",
-      "integrity": "sha512-929qWGDVCRph7gQVTC6koHqQIpF4vtVaSbwLltFQo44B1bYUquALswZdBKFfrJCPEnsCOvWkJsPdQYZ/Ukhw8A==",
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "requires": {
-        "b64-lite": "^1.4.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "backoff": {
@@ -1351,16 +1291,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64url": {
       "version": "3.0.1",
@@ -1501,6 +1431,7 @@
         "promise": "^7.1.1",
         "request": "^2.88.0",
         "rsa-pem-from-mod-exp": "^0.8.4",
+        "skills-validator": "file:node_modules/botbuilder/skills-validator/skills-validator-1.0.0.tgz",
         "sprintf-js": "^1.0.3",
         "url-join": "^1.1.0"
       },
@@ -2015,9 +1946,9 @@
       }
     },
     "bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2026,15 +1957,6 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "optional": true,
-      "requires": {
-        "fill-range": "^7.0.1"
       }
     },
     "browser-request": {
@@ -2046,15 +1968,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
       "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -2174,21 +2087,6 @@
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "optional": true,
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "optional": true
-    },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
@@ -2206,12 +2104,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
-    },
-    "compare-versions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
-      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2313,9 +2205,9 @@
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
     },
     "ctype": {
       "version": "0.5.3",
@@ -2350,6 +2242,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "date-utils": {
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+      "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA=="
     },
     "dayjs": {
       "version": "1.11.10",
@@ -2567,58 +2464,12 @@
         "original": ">=0.0.5"
       }
     },
-    "exifr": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/exifr/-/exifr-5.0.6.tgz",
-      "integrity": "sha512-iDB4IhKoKVF+uDDrHRlyNxWqGaTxYluVWqvBWVG54HkQZe8qkFYl9eQrjEP3d8Q4UMBZ9rWu3Pa+mfC+o4CZuw=="
-    },
-    "expo-modules-autolinking": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-0.0.3.tgz",
-      "integrity": "sha512-azkCRYj/DxbK4udDuDxA9beYzQTwpJ5a9QA0bBgha2jHtWdFGF4ZZWSY+zNA5mtU3KqzYt8jWHfoqgSvKyu1Aw==",
-      "optional": true,
+    "exif": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/exif/-/exif-0.6.0.tgz",
+      "integrity": "sha512-gEwM4uanNMfLnDNKclZ7jPEA99E3rpy4ntoS6QW8u6murZjl1o8qRaPdMoC46Syg3d9/QaET0bYKhWlTwJCPgg==",
       "requires": {
-        "chalk": "^4.1.0",
-        "commander": "^7.2.0",
-        "fast-glob": "^3.2.5",
-        "find-up": "~5.0.0",
-        "fs-extra": "^9.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-          "optional": true
-        }
-      }
-    },
-    "expo-random": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-13.4.0.tgz",
-      "integrity": "sha512-Z/Bbd+1MbkK8/4ukspgA3oMlcu0q3YTCu//7q2xHwy35huN6WCv4/Uw2OGyCiOQjAbU02zwq6swA+VgVmJRCEw==",
-      "optional": true,
-      "requires": {
-        "base64-js": "^1.3.0"
+        "debug": "^2.2"
       }
     },
     "express": {
@@ -2755,19 +2606,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
-    "fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "optional": true,
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      }
-    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2778,15 +2616,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
-    "fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "optional": true,
-      "requires": {
-        "reusify": "^1.0.4"
-      }
-    },
     "faye-websocket": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
@@ -2796,23 +2625,9 @@
       }
     },
     "file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "requires": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      }
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "optional": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA=="
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -2847,16 +2662,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
       "integrity": "sha512-GyDxVgA61TZcrgDJPqOqGBpi80Uf2yIstubgizi7AjC9yPdRrqBR+Y0MvK4kXnYlaoz3d+SGxDHMYVkwI/yd2w=="
-    },
-    "find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "optional": true,
-      "requires": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      }
     },
     "flowdock": {
       "version": "0.9.1",
@@ -3069,18 +2874,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
-    "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "optional": true,
-      "requires": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
     "fs-jetpack": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-0.13.3.tgz",
@@ -3141,15 +2934,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "optional": true,
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
-    },
     "global": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
@@ -3193,12 +2977,6 @@
         "get-intrinsic": "^1.1.3"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "optional": true
-    },
     "handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -3239,12 +3017,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "optional": true
     },
     "has-property-descriptors": {
       "version": "1.0.1",
@@ -3566,11 +3338,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3584,20 +3351,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "optional": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "ip-anonymize": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ip-anonymize/-/ip-anonymize-0.1.0.tgz",
-      "integrity": "sha512-cZJu+N5JKKFGMK0eEQWNaQMn2EhCysciVM6eotCJwfqotj16BTfVchKsJCH6mQAT9N0GC7oWRcsZ6Lb8dDiwTA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -3623,25 +3376,10 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "optional": true
-    },
     "is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
       "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "optional": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
@@ -3659,12 +3397,6 @@
         "jsonpointer": "^4.0.0",
         "xtend": "^4.0.0"
       }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "optional": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -3708,24 +3440,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
-    },
-    "isomorphic-webcrypto": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/isomorphic-webcrypto/-/isomorphic-webcrypto-2.3.8.tgz",
-      "integrity": "sha512-XddQSI0WYlSCjxtm1AI8kWQOulf7hAN3k3DclF1sxDJZqOe0pcsOt675zvWW91cZH9hYs3nlA3Ev8QK5i80SxQ==",
-      "requires": {
-        "@peculiar/webcrypto": "^1.0.22",
-        "@unimodules/core": "*",
-        "@unimodules/react-native-adapter": "*",
-        "asmcrypto.js": "^0.22.0",
-        "b64-lite": "^1.3.1",
-        "b64u-lite": "^1.0.1",
-        "expo-random": "*",
-        "msrcrypto": "^1.5.6",
-        "react-native-securerandom": "^0.1.1",
-        "str2buf": "^1.3.0",
-        "webcrypto-shim": "^0.1.4"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -3778,12 +3492,6 @@
       "resolved": "https://registry.npmjs.org/javascript-state-machine/-/javascript-state-machine-3.1.0.tgz",
       "integrity": "sha512-BwhYxQ1OPenBPXC735RgfB+ZUG8H3kjsx8hrYTgWnoy6TPipEy4fiicyhT2lxRKAXq9pG7CfFT8a2HLr6Hmwxg=="
     },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "optional": true
-    },
     "js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -3813,16 +3521,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
-      }
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -3900,15 +3598,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "optional": true,
-      "requires": {
-        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -3994,14 +3683,9 @@
       }
     },
     "lodash.clone": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
-      "integrity": "sha512-yVYPpFTdZDCLG2p07gVRTvcwN5X04oj2hu4gG6r0fer58JA08wAVxXzWM+CmmxO2bzOH8u8BkZTZqgX6juVF7A==",
-      "requires": {
-        "lodash._baseclone": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
-      }
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg=="
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
@@ -4012,10 +3696,25 @@
         "lodash._bindcallback": "^3.0.0"
       }
     },
+    "lodash.fill": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.fill/-/lodash.fill-3.4.0.tgz",
+      "integrity": "sha512-YgunwHKIxPWOe3VnM65J3oi6oShakIxdLMeIZ9xxcsMxc8X/FQC2VlA4eJzMv+7GlC5gebQLn+U+qcNoG18iLA=="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.intersection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
+      "integrity": "sha512-N+L0cCfnqMv6mxXtSPeKt+IavbOBBSiAEkKyLasZ8BVcP9YXQgxLO12oPR8OyURwKV8l5vJKiE1M8aS70heuMg=="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -4062,15 +3761,40 @@
         "lodash.isarray": "^3.0.0"
       }
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
+    "lodash.partialright": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+      "integrity": "sha512-yebmPMQZH7i4El6SdJTW9rn8irWl8VTcsmiWqm/I4sY8/ZjbSo0Z512HL6soeAu3mh5rhx5uIIo6kYJOQXbCxw=="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
+    },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw=="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
     "log": {
       "version": "1.4.0",
@@ -4078,18 +3802,9 @@
       "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
     "long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "optional": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg=="
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -4304,26 +4019,10 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "optional": true
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
-    },
-    "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "optional": true,
-      "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      }
     },
     "mime": {
       "version": "1.6.0",
@@ -4549,11 +4248,6 @@
         }
       }
     },
-    "msrcrypto": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/msrcrypto/-/msrcrypto-1.5.8.tgz",
-      "integrity": "sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q=="
-    },
     "multiparty": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.2.3.tgz",
@@ -4619,10 +4313,18 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-icu-charset-detector": {
       "version": "0.2.0",
@@ -4634,42 +4336,43 @@
       }
     },
     "node-jose": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.2.0.tgz",
-      "integrity": "sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-0.11.1.tgz",
+      "integrity": "sha512-1mX5prmancKdOgMI/85uduqWNFg63traxVdun7dNNsX4AUs6HqztJhzfBlIWfSujQ8Rah9dWLGUFlXORxZvvzg==",
       "requires": {
-        "base64url": "^3.0.1",
-        "buffer": "^6.0.3",
-        "es6-promise": "^4.2.8",
-        "lodash": "^4.17.21",
-        "long": "^5.2.0",
-        "node-forge": "^1.2.1",
-        "pako": "^2.0.4",
-        "process": "^0.11.10",
-        "uuid": "^9.0.0"
+        "b64u": "^2.0.0",
+        "es6-promise": "^4.0.5",
+        "lodash.assign": "^4.0.8",
+        "lodash.clone": "^4.3.2",
+        "lodash.fill": "^3.2.2",
+        "lodash.flatten": "^4.2.0",
+        "lodash.intersection": "^4.1.2",
+        "lodash.merge": "^4.3.5",
+        "lodash.omit": "^4.2.1",
+        "lodash.partialright": "^4.1.3",
+        "lodash.pick": "^4.2.0",
+        "lodash.uniq": "^4.2.1",
+        "long": "^3.1.0",
+        "node-forge": "^0.7.1",
+        "uuid": "^3.0.1"
       },
       "dependencies": {
-        "es6-promise": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-        },
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        "lodash.assign": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
         }
       }
     },
     "node-kms": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.4.0.tgz",
-      "integrity": "sha512-Tvhs7XTvBgWLZUrAeLKDqzvlomaZWwMoIXWImMc/IbvTijLoOrkovZo+PeW0ivf/8fBlg5EihPCwKg/dy9r+sA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.3.2.tgz",
+      "integrity": "sha512-nQZ6H0UVQ4PiUWRoTvobvwHgAdRv8WMUzBiFbJK9FU5PmPWZwawa6wWve2wv+JK+we3q4qUNH/c1TdEj2Vwhqw==",
       "requires": {
         "es6-promise": "^2.0.1",
         "lodash.clone": "^3.0.2",
         "lodash.clonedeep": "^3.0.1",
-        "node-jose": "^2.0.0",
+        "node-jose": ">=0.3.0 <1.0",
         "uuid": "^2.0.1"
       },
       "dependencies": {
@@ -4677,6 +4380,16 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
           "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
+        },
+        "lodash.clone": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+          "integrity": "sha512-yVYPpFTdZDCLG2p07gVRTvcwN5X04oj2hu4gG6r0fer58JA08wAVxXzWM+CmmxO2bzOH8u8BkZTZqgX6juVF7A==",
+          "requires": {
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
         },
         "uuid": {
           "version": "2.0.3",
@@ -4686,19 +4399,29 @@
       }
     },
     "node-scr": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.3.0.tgz",
-      "integrity": "sha512-Hb0ykojynSbt7ra6eml6NX39WAumFfU3G81XvLpp2H7y8KjQc29oEIf2TlgZQCfA+pyxbY5t4a1xBqPpyrbpvw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.2.2.tgz",
+      "integrity": "sha512-dLLUGB/2F1x9OfNjxhyXfye0UF0y4rC0DOX01z9Fo055GwbC079uXe1H9q1JnyXbi7SCz9nCzHKtsw6cXCJiVw==",
       "requires": {
         "es6-promise": "^2.0.1",
         "lodash.clone": "^3.0.2",
-        "node-jose": "^2.0.0"
+        "node-jose": ">=0.3.0 <1.0"
       },
       "dependencies": {
         "es6-promise": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
           "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
+        },
+        "lodash.clone": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+          "integrity": "sha512-yVYPpFTdZDCLG2p07gVRTvcwN5X04oj2hu4gG6r0fer58JA08wAVxXzWM+CmmxO2bzOH8u8BkZTZqgX6juVF7A==",
+          "requires": {
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
         }
       }
     },
@@ -4828,29 +4551,6 @@
         "url-parse": "^1.4.3"
       }
     },
-    "p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "optional": true,
-      "requires": {
-        "yocto-queue": "^0.1.0"
-      }
-    },
-    "p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "optional": true,
-      "requires": {
-        "p-limit": "^3.0.2"
-      }
-    },
-    "pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
-    },
     "parent-require": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
@@ -4866,12 +4566,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
-    "path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "optional": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4882,21 +4576,10 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "optional": true
     },
     "pkginfo": {
       "version": "0.4.1",
@@ -5000,12 +4683,6 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "optional": true
-    },
     "random-bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
@@ -5066,15 +4743,6 @@
         }
       }
     },
-    "react-native-securerandom": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz",
-      "integrity": "sha512-CozcCx0lpBLevxiXEb86kwLRalBCHNjiGPlw3P7Fi27U6ZLdfjOCNRHD1LtBKcvPvI3TvkBXB3GOtLvqaYJLGw==",
-      "optional": true,
-      "requires": {
-        "base64-js": "*"
-      }
-    },
     "readable-stream": {
       "version": "1.0.34",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -5084,39 +4752,6 @@
         "inherits": "~2.0.1",
         "isarray": "0.0.1",
         "string_decoder": "~0.10.x"
-      }
-    },
-    "readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "requires": {
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
       }
     },
     "reconnect-core": {
@@ -5134,9 +4769,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "request": {
       "version": "2.85.0",
@@ -5182,12 +4817,6 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
       "integrity": "sha512-bkzdIZ5Xyim12j0jq6CQAHpfdsa2VqieWF6eN8vT2MXxCxLAZhgVUyu5EEMevJyXML+XWTxVbZ7mLaKx5F/DZw=="
     },
-    "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "optional": true
-    },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.6",
       "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.6.tgz",
@@ -5198,23 +4827,6 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
     },
-    "rtcpeerconnection-shim": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
-      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
-      "requires": {
-        "sdp": "^2.6.0"
-      }
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "optional": true,
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -5224,11 +4836,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sdp": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
-      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
     },
     "sdp-transform": {
       "version": "2.14.1",
@@ -5366,6 +4973,15 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "skills-validator": {
+      "version": "file:node_modules/botbuilder/skills-validator/skills-validator-1.0.0.tgz",
+      "integrity": "sha512-UFmS/Tj/1LcrwWkL8jqStUeKRHp3G5Ee2FmRJzerSOJIjSlTXePvvqTpKSxb1iXnZz7+BPayXAaSIMCfvKWcFQ==",
+      "requires": {
+        "@types/node-fetch": "^2.5.4",
+        "adal-node": "^0.2.1",
+        "node-fetch": "^2.6.0"
+      }
+    },
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
@@ -5432,11 +5048,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
     },
-    "str2buf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/str2buf/-/str2buf-1.3.0.tgz",
-      "integrity": "sha512-xIBmHIUHYZDP4HyoXGHYNVmxlXLXDrtFHYT0eV6IOdEj3VO9ccaF1Ejl9Oq8iFjITllpT8FhaXb4KsNmw+3EuA=="
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -5453,24 +5064,6 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
-      }
-    },
-    "strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-      "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
-      }
-    },
-    "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "optional": true,
-      "requires": {
-        "has-flag": "^4.0.0"
       }
     },
     "text-encoding": {
@@ -5497,28 +5090,10 @@
       "resolved": "https://registry.npmjs.org/tls-connect/-/tls-connect-0.2.2.tgz",
       "integrity": "sha512-iV92SmsU+iB+TZKeZxBRTyk8T0RAXDjpwoYjG28HMm5E0ilPfrfqidDntRL4ZswoqRv81Kx05PqbK6CN7olrKQ=="
     },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "optional": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
-    "token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-      "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      }
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -5527,6 +5102,11 @@
       "requires": {
         "punycode": "^1.4.1"
       }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "truncate": {
       "version": "2.1.0",
@@ -5618,6 +5198,11 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
+    "underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+    },
     "uni-global": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
@@ -5625,12 +5210,6 @@
       "requires": {
         "type": "^2.5.0"
       }
-    },
-    "universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "optional": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -5670,11 +5249,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
       "integrity": "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -5730,48 +5304,37 @@
         }
       }
     },
-    "webcrypto-shim": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
-      "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
-    },
     "webex": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/webex/-/webex-1.161.0.tgz",
-      "integrity": "sha512-fEheKltkfHrZCNHtZPHZjLPicb47JiKQzKcO/J+26n6snYsLnmhU0y8BHsbWkuudD1RuXZV/kFBSd6/nzWFO4w==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-1.80.178.tgz",
+      "integrity": "sha512-DNMYNMPlZqRF1IrwjAmThw2jc7mtV44mz+CzMoH92UGRVYoLaDoO/kxb0nZ8NNiiH99ciUbjnGRNnJ0wa/hX4A==",
       "requires": {
-        "@babel/polyfill": "^7.12.1",
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-calendar": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-presence": "1.161.0",
-        "@webex/internal-plugin-support": "1.161.0",
-        "@webex/plugin-attachment-actions": "1.161.0",
-        "@webex/plugin-authorization": "1.161.0",
-        "@webex/plugin-device-manager": "1.161.0",
-        "@webex/plugin-logger": "1.161.0",
-        "@webex/plugin-meetings": "1.161.0",
-        "@webex/plugin-memberships": "1.161.0",
-        "@webex/plugin-messages": "1.161.0",
-        "@webex/plugin-people": "1.161.0",
-        "@webex/plugin-rooms": "1.161.0",
-        "@webex/plugin-team-memberships": "1.161.0",
-        "@webex/plugin-teams": "1.161.0",
-        "@webex/plugin-webhooks": "1.161.0",
-        "@webex/storage-adapter-local-storage": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-calendar": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-presence": "1.80.178",
+        "@webex/plugin-attachment-actions": "1.80.178",
+        "@webex/plugin-authorization": "1.80.178",
+        "@webex/plugin-device-manager": "1.80.178",
+        "@webex/plugin-logger": "1.80.178",
+        "@webex/plugin-meetings": "1.80.178",
+        "@webex/plugin-memberships": "1.80.178",
+        "@webex/plugin-messages": "1.80.178",
+        "@webex/plugin-people": "1.80.178",
+        "@webex/plugin-rooms": "1.80.178",
+        "@webex/plugin-team-memberships": "1.80.178",
+        "@webex/plugin-teams": "1.80.178",
+        "@webex/plugin-webhooks": "1.80.178",
+        "@webex/storage-adapter-local-storage": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-polyfill": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       }
     },
-    "webrtc-adapter": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
-      "integrity": "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==",
-      "requires": {
-        "rtcpeerconnection-shim": "^1.2.15",
-        "sdp": "^2.12.0"
-      }
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "websocket-driver": {
       "version": "0.7.0",
@@ -5786,6 +5349,15 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",
@@ -5839,6 +5411,11 @@
         "ultron": "1.0.x"
       }
     },
+    "xpath.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -5848,12 +5425,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "optional": true
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,111 +4,54 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "@babel/runtime-corejs2": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.23.4.tgz",
-      "integrity": "sha512-w10wlnER4ZJ60UlxQWiDhaD1nxHrJ3YgGK2V5iws7a07Q1+vQw4eL54kdtuPIadE3LkeG/Xtg+TEI5zWgjYEjw==",
-      "requires": {
-        "core-js": "^2.6.12",
-        "regenerator-runtime": "^0.14.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-        }
-      }
-    },
     "@danielkalen/source-map-support": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@danielkalen/source-map-support/-/source-map-support-0.4.16.tgz",
       "integrity": "sha512-1lc1ptKNT+f6eS9FA7sJPAeqjM00xfwcEU6fBjVa6VLPI0pjGJHRoxBuA2ghQ16TyjilDnCxZb6dQl+WW54CKg==",
       "requires": {
         "source-map": "^0.5.6"
-      }
-    },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "optional": true,
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "optional": true
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "optional": true,
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      }
-    },
-    "@peculiar/asn1-schema": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
-      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
-      "requires": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
       },
       "dependencies": {
-        "asn1js": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-          "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-          "requires": {
-            "pvtsutils": "^1.3.2",
-            "pvutils": "^1.1.3",
-            "tslib": "^2.4.0"
-          }
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
-    "@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+    "@peculiar/asn1-schema": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-1.1.2.tgz",
+      "integrity": "sha512-ntQ4UnUFgdjs0tfWR6YmEQm/x0glV4OFus/RjxLkaJUKfu/R7VilefBntyUO3MoKWdlCgib30KN+JpCY1HqU2A==",
       "requires": {
-        "tslib": "^2.0.0"
+        "asn1js": "^2.0.26",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.10.tgz",
+      "integrity": "sha512-kbpnG9CkF1y6wwGkW7YtSA+yYK4X5uk4rAwsd1hxiaYE3Hkw2EsGlbGh/COkMLyFf+Fe830BoFiMSB3QnC/ItA==",
+      "requires": {
+        "tslib": "^1.11.1"
       }
     },
     "@peculiar/webcrypto": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.0.27.tgz",
+      "integrity": "sha512-sERMakD19gNhwBVXGGoJjBfc28bDbd2YWaio7/x8jKtvwMKNuljM7ANQ6LzEkEvqFAyjf3bhBZktJ6UXy/0Plg==",
       "requires": {
-        "@peculiar/asn1-schema": "^2.3.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.5.0",
-        "webcrypto-core": "^1.7.7"
+        "@peculiar/asn1-schema": "^1.0.5",
+        "@peculiar/json-schema": "^1.1.10",
+        "pvtsutils": "^1.0.10",
+        "tslib": "^1.11.1",
+        "webcrypto-core": "^1.0.19-next.0"
       }
     },
     "@rocket.chat/sdk": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@rocket.chat/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-KPN8RuAfaGQg0R/MguvlnwNFKm4UI84U7g0YYOVIc6rzpGc+ON2dh/sLyoEtJdDKGwOtF9oogs14mMO3cLHkFA==",
+      "resolved": "http://registry.npmjs.org/@rocket.chat/sdk/-/sdk-0.1.0.tgz",
+      "integrity": "sha1-uFcXq9gf1bSFcm62tgno8bUKuBg=",
       "requires": {
         "@types/lru-cache": "^4.1.0",
         "@types/node": "^9.4.6",
@@ -135,310 +78,479 @@
         "ws": "^1.0.1"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
         "bluebird": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-        },
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          }
-        },
-        "url-join": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-          "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw=="
-        },
-        "ws": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-          "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
-          }
         }
       }
     },
-    "@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
     "@types/async": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.2.tgz",
-      "integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.1.tgz",
+      "integrity": "sha1-Q8Oyxg6rQcJcoACcB8p9YZ2UMRk="
     },
     "@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+      "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "@types/caseless": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
-      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g="
     },
     "@types/clone-deep": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.4.tgz",
-      "integrity": "sha512-vXh6JuuaAha6sqEbJueYdh5zNBPPgG1OYumuz2UvLvriN6ABHDSW8ludREGWJb1MLIzbwZn4q4zUbUCerJTJfA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-bdkCSkyVHsgl3Goe1y16T9k6JuQx7SiDREkq728QjKmTZkGJZuS8R3gGcnGzVuGBP0mssKrzM/GlMOQxtip9cg=="
     },
     "@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
+      "integrity": "sha1-11a9GoXDTYfq9EyIi60nuopLfPA=",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
+        "@types/express-serve-static-core": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.2.tgz",
+      "integrity": "sha1-XuiiLmAgBb5nZ99rLLqYed8/dao=",
       "requires": {
         "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
+        "@types/range-parser": "*"
       }
     },
     "@types/form-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
-      "integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
       "requires": {
-        "form-data": "*"
+        "@types/node": "*"
       }
-    },
-    "@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "@types/jsonwebtoken": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
-      "integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
+      "integrity": "sha1-jRmdq03bW7oyNPgxG4BNICevKzo=",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-QjCOmf5kYwekcsfEKhcEHMK8/SvgnneuSDXFERBuC/DPca2KJIO/gpChTsVb35BoWLBpEAJWz1GFVEArSdtKtw=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha1-sth6Xj341LGMpCbFEFzXAcIwbUA="
     },
     "@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50="
     },
     "@types/node": {
-      "version": "9.6.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
-      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
-    },
-    "@types/qs": {
-      "version": "6.9.10",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
+      "version": "9.6.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.36.tgz",
+      "integrity": "sha1-xKK9sW06ebNOAUZLS9OMG4Se/aw="
     },
     "@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
     },
     "@types/request": {
-      "version": "2.48.12",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
-      "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
+      "integrity": "sha1-5ALWkapmcPu/8ZV7FfEnAjCrQvo=",
       "requires": {
         "@types/caseless": "*",
+        "@types/form-data": "*",
         "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
+        "@types/tough-cookie": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
+    "@types/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha1-pPy4THNE859w3E7sDh5/EKSFl6M="
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha1-naRO11VxmZtlw3tgybK4jbVMWF0="
+    },
+    "@types/url-join": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.3.tgz",
+      "integrity": "sha1-E19AoBFA7TO1IoNume0g38EFYTc="
+    },
+    "@webex/common": {
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.80.178.tgz",
+      "integrity": "sha512-UMZSSUxomcvnFvOt3/IiNMBDLGeLMPR62u/9ZJ6R0qUPsIIJpO9yBI+6N04fJS4hvTBinDMeD66ql42hATRmiQ==",
+      "requires": {
+        "@webex/common": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "backoff": "^2.5.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.15",
+        "urlsafe-base64": "^1.0.0"
       },
       "dependencies": {
+        "backoff": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+          "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+          "requires": {
+            "precond": "0.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "precond": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+          "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+        }
+      }
+    },
+    "@webex/common-timers": {
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.80.178.tgz",
+      "integrity": "sha512-BJUWfDtqareL6HJbLjTk2dmiuGqwtDGHQF50YFKkz6ck2ZapmJZSsox3q3tsImLavYfrF0ltQYnRCLOx0q4mww==",
+      "requires": {
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/helper-html": {
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.80.178.tgz",
+      "integrity": "sha512-08pTVqvvNvXRsqvtSHz34At8Y6eMBGs5P1byvYdl6CE80LIfng69+cNFPzQTLKvRFmP+o3GZc9Uj8Yc1GINaWQ==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "@webex/helper-image": {
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.80.178.tgz",
+      "integrity": "sha512-LwnqJCP7/yank0dVM5qiq9K1ALFPgHl68Z9AfObNSorNC8PljdcG/hsowNkM9rj/s0rv9+eB53hbL0g68FIzJA==",
+      "requires": {
+        "@webex/http-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "envify": "^4.1.0",
+        "exif": "^0.6.0",
+        "gm": "^1.23.1",
+        "lodash": "^4.17.15",
+        "mime-types": "^2.1.24"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "mime-db": {
+          "version": "1.43.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.26",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "requires": {
+            "mime-db": "1.43.0"
+          }
+        }
+      }
+    },
+    "@webex/http-core": {
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.80.178.tgz",
+      "integrity": "sha512-iBaHvEaX9KdMaB4mUM+dpyM56qWOplI4GFDVAxYmf8SLZMiiQwjCC6gu/TLMTBcg4vPiQwO/9tHVPCkk//vNFA==",
+      "requires": {
+        "@webex/common": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "envify": "^4.1.0",
+        "file-type": "^3.9.0",
+        "global": "^4.4.0",
+        "is-function": "^1.0.1",
+        "lodash": "^4.17.15",
+        "parse-headers": "^2.0.2",
+        "qs": "^6.7.0",
+        "request": "^2.88.0",
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
         "form-data": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
-        }
-      }
-    },
-    "@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "requires": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "@types/serve-static": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
-      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
-      "requires": {
-        "@types/http-errors": "*",
-        "@types/mime": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/sprintf-js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.4.tgz",
-      "integrity": "sha512-aWK1reDYWxcjgcIIPmQi3u+OQDuYa9b+lr6eIsGWrekJ9vr1NSjr4Eab8oQ1iKuH1ltFHpXGyerAv1a3FMKxzQ=="
-    },
-    "@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
-    },
-    "@types/url-join": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.6.tgz",
-      "integrity": "sha512-7ynfYbbQHV3iz7K77wzgVoBBisyoMuFhLSoIhs1dl49WPzMZ0ybVqUq6Opa6n+0vBaWDXmzNbBkeNzsmPFWDJA=="
-    },
-    "@unimodules/core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@unimodules/core/-/core-7.1.2.tgz",
-      "integrity": "sha512-lY+e2TAFuebD3vshHMIRqru3X4+k7Xkba4Wa7QsDBd+ex4c4N2dHAO61E2SrGD9+TRBD8w/o7mzK6ljbqRnbyg==",
-      "optional": true,
-      "requires": {
-        "compare-versions": "^3.4.0"
-      }
-    },
-    "@unimodules/react-native-adapter": {
-      "version": "6.3.9",
-      "resolved": "https://registry.npmjs.org/@unimodules/react-native-adapter/-/react-native-adapter-6.3.9.tgz",
-      "integrity": "sha512-i9/9Si4AQ8awls+YGAKkByFbeAsOPgUNeLoYeh2SQ3ddjxJ5ZJDtq/I74clDnpDcn8zS9pYlcDJ9fgVJa39Glw==",
-      "optional": true,
-      "requires": {
-        "expo-modules-autolinking": "^0.0.3",
-        "invariant": "^2.2.4"
-      }
-    },
-    "@webex/common": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.161.0.tgz",
-      "integrity": "sha512-gY0IK2yeNv10b6AYrXa5FAicDvYd91jkY4Mf/L1UosuOLHA8UEVRNIQxMDPSdoaHUXBk+WI6rti1d/XnQFz8QQ==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "backoff": "^2.5.0",
-        "bowser": "^2.11.0",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "global": "^4.4.0",
-        "lodash": "^4.17.21",
-        "safe-buffer": "^5.2.0",
-        "urlsafe-base64": "^1.0.0"
-      }
-    },
-    "@webex/common-timers": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.161.0.tgz",
-      "integrity": "sha512-30oeHYvnhfP79KRw5+tDbzOkqXslPy4xjcQMYDWTsg/xvUeSaX9Wf7Odumnkspee4SNuqcqYTCKP7Pc8ZCSVHg==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/helper-html": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.161.0.tgz",
-      "integrity": "sha512-kQ7UX2X4Oo5R3W42ATIHr/Mb/VpJO+FNRtHQaPFs5vmLUT4Zy4hJ7AHn1Mo7FkOIn40eAe5ezSs/x+ifsal/aw==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "@webex/helper-image": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.161.0.tgz",
-      "integrity": "sha512-KdkVqS7D0hoDKCTFDcVMmDy7UhAEynitTkXlwHYJFigiq5Lq0R/YHdk7DiziHMABMxfrq6vl9mhUakzXjhQCAg==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/http-core": "1.161.0",
-        "envify": "^4.1.0",
-        "exifr": "^5.0.3",
-        "gm": "^1.23.1",
-        "lodash": "^4.17.21",
-        "mime": "^2.4.4",
-        "safe-buffer": "^5.2.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
-        }
-      }
-    },
-    "@webex/http-core": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.161.0.tgz",
-      "integrity": "sha512-2JCvZ1lJwwv2Ajn9cn7QrbD6QbMR1p9pXu2JcjhYP2WdHssT6pBvNMZ009uJ1JRGexY3QQKuBNlzn8M87xbQtw==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "envify": "^4.1.0",
-        "file-type": "^16.0.1",
-        "global": "^4.4.0",
-        "is-function": "^1.0.1",
-        "lodash": "^4.17.21",
-        "parse-headers": "^2.0.2",
-        "qs": "^6.7.0",
-        "request": "^2.88.0",
-        "safe-buffer": "^5.2.0",
-        "xtend": "^4.0.2"
-      },
-      "dependencies": {
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha512-4Dj8Rf+fQ+/Pn7C5qeEX02op1WfOss3PKTE9Nsop3Dx+6UPxlm1dr/og7o2cRa5hNN07CACr4NFzRLtj/rjWog==",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "mime-db": {
+          "version": "1.43.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.26",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "requires": {
+            "mime-db": "1.43.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "psl": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+          "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
         "qs": {
           "version": "6.11.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
@@ -446,82 +558,216 @@
           "requires": {
             "side-channel": "^1.0.4"
           }
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "sshpk": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+          "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "verror": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         }
       }
     },
     "@webex/internal-plugin-calendar": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.161.0.tgz",
-      "integrity": "sha512-tbw50C4rW6MAWpu8rD1wQyivmDjR6lA6dSYwddy2jNNvmmq0lOkR0CQjry2KTxbzpFQzptXEMmpXbMZFCRCLKw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.80.178.tgz",
+      "integrity": "sha512-kl4MUC5crbKPEAbQKa6ELc/26CkQXQMBOlHcUKgvBNXkUl7YlM6ezWfBRnZr1AAYNGMW9Ezzd+TvL1iojg5n2Q==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-encryption": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-encryption": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "btoa": "^1.2.1",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "@webex/internal-plugin-conversation": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.161.0.tgz",
-      "integrity": "sha512-1/yud5FtF7QXHJn+NspdDaBF5ecQmnoafX+8LiZhnOSO8/eCuWPkBqzxTc7hvnI0+oluontZHKR2ZN6wrREn1Q==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.80.178.tgz",
+      "integrity": "sha512-yB+3KCHMAi0YN/sDbaN0NeC/NzNe8Em5AaLID+9CqGE5G/94QTW4O2YssyqJJ2CvDhLlhXS5B0HsqbJGAKgQMA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/helper-html": "1.161.0",
-        "@webex/helper-image": "1.161.0",
-        "@webex/internal-plugin-encryption": "1.161.0",
-        "@webex/internal-plugin-user": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "crypto-js": "^4.1.1",
+        "@webex/common": "1.80.178",
+        "@webex/helper-html": "1.80.178",
+        "@webex/helper-image": "1.80.178",
+        "@webex/internal-plugin-encryption": "1.80.178",
+        "@webex/internal-plugin-user": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "crypto-js": "^3.1.9-1",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21",
-        "node-scr": "^0.3.0",
+        "lodash": "^4.17.15",
+        "node-scr": "^0.2.2",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "@webex/internal-plugin-device": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-1.161.0.tgz",
-      "integrity": "sha512-y8MV6gmHdC/5WijCPrTXNmQGRSqt4WADNT4CzdyYBtAkybOHRJRineE2IqhH72MRYkh/+aDBjW2mvbGhMUkwWg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-1.80.178.tgz",
+      "integrity": "sha512-1QJ+cy2OKOzKpFMEj0Qq51/e2vWFhpoqxpcClGZ+D3tt5H/xHa1GHtgdWXSalfF/PKJl6TSnR0sgD/p3MoQcBQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/http-core": "1.161.0",
-        "@webex/internal-plugin-metrics": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/http-core": "1.80.178",
+        "@webex/webex-core": "1.80.178",
         "ampersand-collection": "^2.0.2",
         "ampersand-state": "^5.0.3",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "@webex/internal-plugin-encryption": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.161.0.tgz",
-      "integrity": "sha512-Fgq4UyHLmKhfwWQBBLhK+Krz0UIB/cu3nwPnNr2EvUb7ZeoxPcd+jnMEHp+QDEUMa41Vr59pYPPBxvhtv1CLqg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.80.178.tgz",
+      "integrity": "sha512-R2AJh/cA/g3vIgYmbkqOxE/Z/Trj1cl640Ldshj7wwT7cX/KTmLD3dChP4uyV0X316v5EofZRwLyMSi4qX/Ysw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/http-core": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@peculiar/webcrypto": "^1.0.22",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/http-core": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
         "asn1js": "^2.0.26",
+        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "isomorphic-webcrypto": "^2.3.8",
-        "lodash": "^4.17.21",
-        "node-jose": "^2.0.0",
-        "node-kms": "^0.4.0",
-        "node-scr": "^0.3.0",
+        "lodash": "^4.17.15",
+        "node-jose": "^0.11.1",
+        "node-kms": "^0.3.2",
+        "node-scr": "^0.2.2",
         "pkijs": "^2.1.84",
-        "safe-buffer": "^5.2.0",
         "valid-url": "^1.0.9"
       },
       "dependencies": {
@@ -532,134 +778,203 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
     "@webex/internal-plugin-feature": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.161.0.tgz",
-      "integrity": "sha512-sKuICbBHWx7Fi60EsdLe0H4preh8XT+I464TJ01bE2EDEldEbl1viFrAE1TOAlkXokWb2+xKEH4c/9hFQqB4VA==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.80.178.tgz",
+      "integrity": "sha512-2UJgZu8F5x0MaLSS5StOLOIEpirYy80uqCRxyTvuqk/6/bJe9dw01kCXZtVT1xC0bya4Z2bjzhzqGkcDaOMF+A==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "@webex/internal-plugin-lyra": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.161.0.tgz",
-      "integrity": "sha512-B50bsDVdvJBNP56j0RbLxlbByIr/CRpRzBTKfGzV6zQoXUYs99inLTCkMc3Q4NwRCISaeBzcO5wFadJG8H62Xg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.80.178.tgz",
+      "integrity": "sha512-023/09xkyc6O8PV3L49dWnxt5HDO5yW4RFhc5zpNwZI6MG+Jpuj9PXgJ6uZ4NJbIMD4T59zcNioPE5f9lj82/A==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-encryption": "1.161.0",
-        "@webex/internal-plugin-feature": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-encryption": "1.80.178",
+        "@webex/internal-plugin-feature": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-mercury": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.161.0.tgz",
-      "integrity": "sha512-wm9STxbSDNj/1iW198LWk7F5M5AgUI1+yonSSUDOvc8QmxRuk7fuk1fZ0VrqNAR7uEkO56gEmnG+91pJTt71eA==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.80.178.tgz",
+      "integrity": "sha512-oKlOIwqTMkkC4C9q6fQ1XTSbL0a0IvO0lrMvr/jF4gLWrg5EszXjuvft+qWB4N5z3hmHGvubrQyUNuqvBhWvaw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-feature": "1.161.0",
-        "@webex/internal-plugin-metrics": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-feature": "1.80.178",
+        "@webex/internal-plugin-metrics": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "backoff": "^2.5.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "uuid": "^3.3.2",
-        "ws": "^8.2.2"
+        "ws": "^4.1.0"
+      },
+      "dependencies": {
+        "async-limiter": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+          "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+        },
+        "backoff": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+          "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+          "requires": {
+            "precond": "0.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "precond": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+          "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "ws": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "@webex/internal-plugin-metrics": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.161.0.tgz",
-      "integrity": "sha512-B/OJhvZlUNBRhPck1IIxJRAg7eTTtry6+/K+wmjLwtfH1FF9HgSOFu0i7cQiyfql/rzLrs4QaG/6PpqiGl+cuQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.80.178.tgz",
+      "integrity": "sha512-gibR0AT/yvmWufCyBZA74THzDez80WTbO28jW+JKidlpcjf6+Gx6SrgQ+nl60I3zHf7v9TVOsHWMsytRQRWNmQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-presence": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.161.0.tgz",
-      "integrity": "sha512-ch8ojz267xyNlOjywHRTg0rKbBGyNZ4CkSTq1N0TaJ2ne0ZM9mZA+mTC2cQ/p4Fi3jQA3iE5FOQZERvxsY5ABw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.80.178.tgz",
+      "integrity": "sha512-/nJ72ttqLkdBOv8Z7wN1yWIPLyaPtJu3GDoshHwXEtvF51WzR5CHt51VhgmOu0g6spejBcYMJ5eNppozrnQqCQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "@webex/internal-plugin-search": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.161.0.tgz",
-      "integrity": "sha512-9wWIPVNrvsOQ8WOjFsOqzT4s5PDvmJz+L+ZKREsyqLsH7RfO92dsjUnIKYhpYQj7TGaByVlmdOzLf//IjJ4N7Q==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.80.178.tgz",
+      "integrity": "sha512-zWojY1Iz2tF3yN9py5tg5d9dkyV8MetMMB01Mp5sCLGjInCEBhwbSMcHTOu2tigzr8pd61Y5EP5pvD7VOWP5Kg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-encryption": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-encryption": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "@webex/internal-plugin-support": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-support/-/internal-plugin-support-1.161.0.tgz",
-      "integrity": "sha512-ye7XQHXApxGnnbMkPRbN1QA2fFFIISvccsn20PJszdVX4GRohGSBhjQxfZlZSK2MaCrGsFR3FhB4/kspURXw6g==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.21",
-        "uuid": "^3.3.2"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "@webex/internal-plugin-user": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.161.0.tgz",
-      "integrity": "sha512-4NHMIi1+0trR5TjhduX5QTQ+8acNhlSJ64XE4nwxRIer0hADAlQXBLPA1IFf72PYG8l2WijQ0vy8tv07Wra50A==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.80.178.tgz",
+      "integrity": "sha512-KXKvxi34IsRXTBj6KTboSVVhLVe6yb43Ht2HPrGp1Yu8Qx8eptnBbKGEZpAJX1KoQEreQxbRnl6t8GnwRdo3Jw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "@webex/plugin-attachment-actions": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.161.0.tgz",
-      "integrity": "sha512-TBtdHUrkv2i6+ABrLvKZv9VLDEGb/LoJ04xTygMMqKgTrRrsmoS62bj1a2AFYaxKbpQdGPTsuV7/6H4wB5Ikzg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.80.178.tgz",
+      "integrity": "sha512-jW/bq/TRbYaTQrZJdri1CWxIk+CCBgtsdj8Uf2utuBz9aT6jEto2jTZOo7w0G8IeIjCqk+yGoVWBGcCBHuc7Xw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -669,130 +984,158 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
     "@webex/plugin-authorization": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.161.0.tgz",
-      "integrity": "sha512-0ZQfYd7Pdr846Guh1BYcSQJtS0woUQVvNebRXGhwr+YZPC4oYLMk5ISrY+1oocXrZbdJdfkka4ij53lhazYA/Q==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.80.178.tgz",
+      "integrity": "sha512-iVSAlJinBVGA48ZUKJW5lG0NSFgvfZwavFe4mD+BKF05NdvTlp9aXRe90evkOWT3VV97rc4PNqd8iqJelaWCPg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/plugin-authorization-browser": "1.161.0",
-        "@webex/plugin-authorization-node": "1.161.0",
+        "@webex/plugin-authorization-browser": "1.80.178",
+        "@webex/plugin-authorization-node": "1.80.178",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-authorization-browser": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.161.0.tgz",
-      "integrity": "sha512-MSipQ/IQ8fWTu3sDWmQoxN0yGXBwwG3cPt9M+tE4QMmzkF+PjBSGTCmIzLy147U24h5d9wQGGJBWSn8tQwbM1Q==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.80.178.tgz",
+      "integrity": "sha512-Z9J+MAQ+29eGEINL1hZv4PwxkyxW3AccAsHxvCmO/h8y/3Cu0x8jQ3xIos7vmmLU5dtqIv0XDktnDmd30/xeNw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "@webex/plugin-authorization-node": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.161.0.tgz",
-      "integrity": "sha512-oYYHjEv/cVt+ZAbos1En4zA7+GtsxabwR0ZnjaHctSSxfpHoemzO68LJXvqJQRIbVl9do6GNizic4PN5KabhfQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.80.178.tgz",
+      "integrity": "sha512-8mAsOKfiPfYSXiAIroxE/GspZMtw0jcm6Rk+ENJhWrXSgQf5XgPrRR/y3uIpZ7PNeboUNObRKkx5vjkwHgbMBQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-device-manager": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.161.0.tgz",
-      "integrity": "sha512-xzIHP0llGJojMeuoMEtgnDPYpbj/HDMprGVMV/AGyCAuOEdY6mORNgbdavXX/YFVPJL6awBb7G6NXd77Aowujg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.80.178.tgz",
+      "integrity": "sha512-AiXCrLl7r2EsJ+SrZYpJKU4MDECVQoSCHR8nJ8V5yGtklKntiHFpj5P6BFOhI6+l6kU3zaCEOhbtQJ0QS37KaA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-lyra": "1.161.0",
-        "@webex/internal-plugin-search": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-lyra": "1.80.178",
+        "@webex/internal-plugin-search": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "@webex/plugin-logger": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.161.0.tgz",
-      "integrity": "sha512-+JHz2Qgm7pHq2Syfv457N0rQPiSivVFqiq3V+KQ1iAUJiDbz3DlUTIGR90njtrcGDdNwHqqwbZonJ6KZUcOotQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.80.178.tgz",
+      "integrity": "sha512-maEaqtjemF+G5fI3/+E4YkpBqPhXIdGXRE4kXaqj1uRG4wiksopYOAroQ0ILtsAo3yOvqXu6KIiwnRZ37Da8cA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "@webex/plugin-meetings": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.161.0.tgz",
-      "integrity": "sha512-nAYh5ZWX+vGDoxLvUHL8/YdT29VsbHZGw/U2q216KDuvxwhDNWGOnHFp32Eudi1cX79phZSOPgjzwtJ4Xq9oYg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.80.178.tgz",
+      "integrity": "sha512-aYKtPkMNPqRDuViCsMtLo3mnoZGxvQiogF1ctB6cckatihQnta/Du8xkcr0fLMyBhwhFcX2F7mx0zCWnUZNpFg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "bowser": "^2.11.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "bowser": "1.9.4",
         "btoa": "^1.2.1",
         "envify": "^4.1.0",
         "global": "^4.4.0",
-        "ip-anonymize": "^0.1.0",
         "javascript-state-machine": "^3.1.0",
-        "lodash": "^4.17.21",
-        "readable-stream": "^3.6.0",
+        "lodash": "^4.17.15",
         "sdp-transform": "^2.12.0",
-        "uuid": "^3.3.2",
-        "webrtc-adapter": "^7.7.0"
+        "uuid": "^3.3.2"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
     "@webex/plugin-memberships": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.161.0.tgz",
-      "integrity": "sha512-pjs7QAKu8E8QN3niULoZqQXkjfrD+Hqxe3S68ZstBPFvLIhmngP6SRPVQ0bKQIY1V25jGQ1fLigfjOnYjgBgMg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.80.178.tgz",
+      "integrity": "sha512-10YCfIuyj89GkBm2EClOafmedQVk9OkDNP5JLnaSDhgzbj/32geFkTApXMrKKaVr7EQLofpvZNtIPKFY+cuCfw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -802,47 +1145,32 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
     "@webex/plugin-messages": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.161.0.tgz",
-      "integrity": "sha512-vDTdYK0zulpK9J1+ucK3ZB+hGCA3lo0hKIscR0ScN33ideaiEDEFFBRqckmdeRammnyHHZ8Avi/kVYxfBbhtZg==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.80.178.tgz",
+      "integrity": "sha512-OUOwR4u51p+Y2sGdIHLSIS33tNJFcUbkZJhT6Rnlu6xevJjwRALcUYJpVvkALNpiLos/j3OOfEc5hk7xCOJoOA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "@webex/plugin-people": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.161.0.tgz",
-      "integrity": "sha512-G6LbPPqgTht0pkorIJLpkChEnAo+R7u9q51KoPOLj1kM9LOqzOT6JA55z/WfzBZRwYITbfL7qV58FhyQ15sOgA==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-rooms": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.161.0.tgz",
-      "integrity": "sha512-9amxryhzajJyyDFpLGa+YCBI4yvPoTgIj30dQZO0TniCbOYw/QM3BRzvtcn8+195V/ePQeR0RYcd9vqwtWy2iw==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/internal-plugin-conversation": "1.161.0",
-        "@webex/internal-plugin-mercury": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -852,74 +1180,139 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "@webex/plugin-people": {
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.80.178.tgz",
+      "integrity": "sha512-bOaxiawzoPUdCrvFaxI9X+NlakOeXR2wv7rereBO2+QGU4tt7TheURhHGWCDggtcwYIqGJv2XipNdJhI4w0dTA==",
+      "requires": {
+        "@webex/common": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-rooms": {
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.80.178.tgz",
+      "integrity": "sha512-ttBOJcil8zJwisK+vAHupFDAtbDT/7BeLIDTaV3YVXn/iHk8jKTPyxu2HDCXlhQvApV8F9sBDrOxigEthqBCEw==",
+      "requires": {
+        "@webex/common": "1.80.178",
+        "@webex/internal-plugin-conversation": "1.80.178",
+        "@webex/internal-plugin-mercury": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
+        "debug": "^3.2.6",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
     "@webex/plugin-team-memberships": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.161.0.tgz",
-      "integrity": "sha512-LIrp/hpd4RSl0gh97xl7xtopz0PSbeoUatO8u4XkBjUAZ6iPjYAyRuu68yXG7QxfCacePF+jdrdnOuhWsBMIVw==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.80.178.tgz",
+      "integrity": "sha512-GsQutBpXmLd4yNdnqJPQYTtmoQaumVhdtk3QJ5P0XHH0NWOATvfr9DFg5H3zDsAGW15Bc3TJ8qXDQ7VaYJ1lLw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/webex-core": "1.161.0",
+        "@webex/webex-core": "1.80.178",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-teams": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.161.0.tgz",
-      "integrity": "sha512-IrZf33pY6FTStoBumxTSAAXSmzQ7Izia6ICPBi79J2MWrt81lm4MQP5OP+eg2Ub2U6kwrflIfTfYPNjG+OVJNQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.80.178.tgz",
+      "integrity": "sha512-Lo32lfa0549TkFeLXlfEDNd4N9k7DspxwEMpQUJzcKgmmuMI9uIQMlRt3uI2fAkQHL+D2AtK2pxsbY2iH2yzWQ==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/webex-core": "1.161.0",
+        "@webex/webex-core": "1.80.178",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-webhooks": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.161.0.tgz",
-      "integrity": "sha512-KA3rUC9ukfxyEiXwJdeZDxk+HDRtwkn5aE5ZAole7HxhidcY7Obvi+NJuSVSvp+W6giC0McFivoLP6UMwnPEww==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.80.178.tgz",
+      "integrity": "sha512-2yPnjMOLHZRUWjxS8uRZQR8Yh8sjqqF+tb/XmXTYwqd7RtLvuGOB1AmWzyUuv0IM2HGQBnViJB4sF84zLZKvZA==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/webex-core": "1.161.0",
+        "@webex/webex-core": "1.80.178",
         "envify": "^4.1.0"
       }
     },
     "@webex/storage-adapter-local-storage": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.161.0.tgz",
-      "integrity": "sha512-Dzh/PQUbGeQ4h7Aq67QlS0uPZM/zldu8GZo8xjpZSGWDQx+t4ygcSXNgbVXLl9FrItZsxNAxBG2WTkNA5dBzIQ==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.80.178.tgz",
+      "integrity": "sha512-wLrhqchxXSL7O0iq8x7HA51H2RCHlRnPptpj+OV0DZt0mrx7phSO2FT2fY7ySyjUkN+QescJAb9QU37pFbn8ug==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/webex-core": "1.161.0",
+        "@webex/webex-core": "1.80.178",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/webex-core": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.161.0.tgz",
-      "integrity": "sha512-vmHdkZMXE+iUso1knXYnREOvm6NyUwLnSao+47xcqIvTKh+zOxl0VbvP+ovVLYux9xnqIyr6IQERDhJjKgml8w==",
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.80.178.tgz",
+      "integrity": "sha512-K8wVB4DCbbCfMz2mH5LG9farSS1LU8dV9vFyoGBSHt/N/Ori502QFmP+dA0lVg1zay3eQt/GHO3XNCI+Q+lnkw==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "1.161.0",
-        "@webex/common-timers": "1.161.0",
-        "@webex/http-core": "1.161.0",
-        "@webex/webex-core": "1.161.0",
+        "@webex/common": "1.80.178",
+        "@webex/common-timers": "1.80.178",
+        "@webex/http-core": "1.80.178",
+        "@webex/webex-core": "1.80.178",
         "ampersand-collection": "^2.0.2",
         "ampersand-events": "^2.0.2",
         "ampersand-state": "^5.0.3",
+        "babel-runtime": "^6.26.0",
         "core-decorators": "^0.20.0",
-        "crypto-js": "^4.1.1",
+        "crypto-js": "^3.1.9-1",
         "envify": "^4.1.0",
         "jsonwebtoken": "^8.5.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q=="
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
     },
     "accepts": {
       "version": "1.3.8",
@@ -928,57 +1321,57 @@
       "requires": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
-      }
-    },
-    "adaptivecards": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.6.tgz",
-      "integrity": "sha512-/l34rvdRzQ20QdGLk+awRUotexu3N4Ih3O0qR8cM+2wWe0pggvWhmFdwVFmM+YgIS5pWtl2u7XAJynUaFIQAIw=="
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
-        "debug": "4"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
+        "mime-db": {
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "mime-types": {
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+          "requires": {
+            "mime-db": "1.52.0"
+          }
         }
       }
     },
-    "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+    "adaptivecards": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.5.tgz",
+      "integrity": "sha512-Rj+QK0qtBOfLGy3ClXylKxL4ze/a6mtPiJL7Ctjyc1Uso9O1x/LAAu49F36ZQbgAa8vWkKW91RKcwBBOxk3HDg=="
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
-        "fast-deep-equal": "^3.1.1",
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "optional": true
     },
     "ampersand-class-extend": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-2.0.0.tgz",
-      "integrity": "sha512-i8hQvA4vZz9UfQAi0A4oBASYOZzlYgjFVkw0K1xpeKNSvq+KYkFOqJKkNvHCbbuKUNJnFk3kECSKPDAJ6ocEOg==",
+      "integrity": "sha1-Uolf+lkhdjSmGI/RhLEEj12Aiv8=",
       "requires": {
         "lodash": "^4.11.1"
       }
@@ -997,7 +1390,7 @@
     "ampersand-events": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
-      "integrity": "sha512-pPnVEJviRxXi9YhZA9j3GwGGBTlDLi+YIoBvrpKXgce+CO1nMlZU2aOV8OJogNuR2YPbptAUHNz7SKX+MvLj8A==",
+      "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
       "requires": {
         "ampersand-version": "^1.0.2",
         "lodash": "^4.6.1"
@@ -1018,7 +1411,7 @@
     "ampersand-version": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ampersand-version/-/ampersand-version-1.0.2.tgz",
-      "integrity": "sha512-FVVLY7Pghtgc8pQl0rF3A3+OS/CZ+/ILLMIYIaO1cA9v5SRkainqUMfSot3fu32svuThIsYK3q9iCsH9W5+mWQ==",
+      "integrity": "sha1-/489TOrE0yzNg/a9Zpc5f3tZ4sA=",
       "requires": {
         "find-root": "^0.1.1",
         "through2": "^0.6.3"
@@ -1027,26 +1420,19 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "~1.0.2"
-      },
-      "dependencies": {
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
-        }
       }
     },
     "array-flatten": {
@@ -1057,48 +1443,44 @@
     "array-next": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-next/-/array-next-0.0.1.tgz",
-      "integrity": "sha512-sBOC/Iaz2hCcYi2XlyRfyZCRUxamlE5NJXEFjE9BTx23HALnWAFsPjGtfrAclt9o3G/38Het2yyeyOd3CEY7lg=="
+      "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
     },
     "array-parallel": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
-      "integrity": "sha512-TDPTwSWW5E4oiFiKmz6RGJ/a80Y91GuLgUYuLd49+XBS75tYo8PNgaT2K/OxuQYqkoI852MDGBorg9OcUSTQ8w=="
+      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
     },
     "array-series": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
-      "integrity": "sha512-L0XlBwfx9QetHOsbLDrE/vh2t018w9462HM3iaFfxRiK83aJjAt/Ja3NMkOW7FICwWTlQBa3ZbL5FKhuQWkDrg=="
+      "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8="
     },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-    },
-    "asmcrypto.js": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-0.22.0.tgz",
-      "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
-      "integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
-      "requires": {
-        "pvutils": "^1.1.3"
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
+      "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+      "dependencies": {
+        "pvutils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+          "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
+        }
       }
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "asteroid": {
       "version": "github:rocketchat/asteroid#a76a53254e381f9487aa2a9be3d874c9a2df6552",
@@ -1111,29 +1493,23 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "optional": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok="
     },
     "axios": {
       "version": "0.21.4",
@@ -1143,49 +1519,51 @@
         "follow-redirects": "^1.14.0"
       }
     },
-    "b64-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
-      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
+    "b64u": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/b64u/-/b64u-2.0.0.tgz",
+      "integrity": "sha512-N3SnhKhQtwm9a4+rdNT0JvnNdPlRwpQZN4tfJwOE3/qJVzM+OlYj/Iz2n1S3KXAQmKHaRwWUNW5gEnjuD8cXHg=="
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "base-64": "^0.1.0"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
       }
     },
-    "b64u-lite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/b64u-lite/-/b64u-lite-1.1.0.tgz",
-      "integrity": "sha512-929qWGDVCRph7gQVTC6koHqQIpF4vtVaSbwLltFQo44B1bYUquALswZdBKFfrJCPEnsCOvWkJsPdQYZ/Ukhw8A==",
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "b64-lite": "^1.4.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "backoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
-      "requires": {
-        "precond": "0.2"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
+      "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+      "integrity": "sha1-Y5nVcuK8P5CpqLItXbsKMtM/eI0="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -1193,35 +1571,29 @@
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
         "safe-buffer": "5.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
       "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha512-njlCs8XLBIK7LCChTWfzWuIAxkpmmLXcL7/igCofFT1B039Sz0IPnAmosN5QaO22lU4qr8LcUz2ojUlE6pLkRQ==",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "requires": {
         "readable-stream": "~1.0.26"
       }
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ=="
+      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "body-parser": {
       "version": "1.20.1",
@@ -1259,6 +1631,11 @@
             "toidentifier": "1.0.1"
           }
         },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
         "on-finished": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -1293,20 +1670,19 @@
       }
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "4.x.x"
       }
     },
     "botbuilder": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.30.0.tgz",
-      "integrity": "sha512-TpqYa75IvU+aa4VXS0ZL0LFGGjDnw/O04XnAc1VzQw+S82s0vA7YHLAKW9LaKkz4f3cdQKskU48+tZsx+D3wzg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.16.0.tgz",
+      "integrity": "sha1-cA6jkYksYm+h+SJojSx0KwaE9QM=",
       "requires": {
         "@types/async": "^2.0.48",
-        "@types/clone-deep": "^4.0.1",
         "@types/express": "^4.11.1",
         "@types/form-data": "^2.2.1",
         "@types/jsonwebtoken": "^7.2.6",
@@ -1317,13 +1693,118 @@
         "async": "^1.5.2",
         "base64url": "^3.0.0",
         "chrono-node": "^1.1.3",
-        "clone-deep": "^4.0.1",
         "jsonwebtoken": "^8.2.2",
         "promise": "^7.1.1",
         "request": "^2.88.0",
         "rsa-pem-from-mod-exp": "^0.8.4",
         "sprintf-js": "^1.0.3",
         "url-join": "^1.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+        },
+        "mime-db": {
+          "version": "1.38.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+          "integrity": "sha1-GiqrFtqesWe0nG5N8tnGjWPY4q0="
+        },
+        "mime-types": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+          "integrity": "sha1-/ms1WhkJJqt2mMmgVWoRGZshmb0=",
+          "requires": {
+            "mime-db": "~1.38.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "url-join": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+        }
       }
     },
     "botbuilder-teams": {
@@ -1337,12 +1818,329 @@
         "ms-rest": "^2.5.0",
         "sprintf-js": "^1.1.1",
         "tsc": "^1.20150623.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "aws4": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+        },
+        "botbuilder": {
+          "version": "3.30.0",
+          "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.30.0.tgz",
+          "integrity": "sha512-TpqYa75IvU+aa4VXS0ZL0LFGGjDnw/O04XnAc1VzQw+S82s0vA7YHLAKW9LaKkz4f3cdQKskU48+tZsx+D3wzg==",
+          "requires": {
+            "@types/async": "^2.0.48",
+            "@types/clone-deep": "^4.0.1",
+            "@types/express": "^4.11.1",
+            "@types/form-data": "^2.2.1",
+            "@types/jsonwebtoken": "^7.2.6",
+            "@types/node": "^9.6.1",
+            "@types/request": "^2.47.0",
+            "@types/sprintf-js": "^1.1.0",
+            "@types/url-join": "^0.8.1",
+            "async": "^1.5.2",
+            "base64url": "^3.0.0",
+            "chrono-node": "^1.1.3",
+            "clone-deep": "^4.0.1",
+            "jsonwebtoken": "^8.2.2",
+            "promise": "^7.1.1",
+            "request": "^2.88.0",
+            "rsa-pem-from-mod-exp": "^0.8.4",
+            "sprintf-js": "^1.0.3",
+            "url-join": "^1.1.0"
+          },
+          "dependencies": {
+            "@types/node-fetch": {
+              "version": "2.5.10",
+              "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+              "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
+              "requires": {
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+              },
+              "dependencies": {
+                "@types/node": {
+                  "version": "15.12.0",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.0.tgz",
+                  "integrity": "sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw=="
+                }
+              }
+            },
+            "adal-node": {
+              "version": "0.2.2",
+              "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.2.tgz",
+              "integrity": "sha512-luzQ9cXOjUlZoCiWeYbyR+nHwScSrPTDTbOInFphQs/PnwNz6wAIVkbsHEXtvYBnjLctByTTI8ccfpGX100oRQ==",
+              "requires": {
+                "@types/node": "^8.0.47",
+                "async": "^2.6.3",
+                "axios": "^0.21.1",
+                "date-utils": "*",
+                "jws": "3.x.x",
+                "underscore": ">= 1.3.1",
+                "uuid": "^3.1.0",
+                "xmldom": ">= 0.1.x",
+                "xpath.js": "~1.1.0"
+              },
+              "dependencies": {
+                "@types/node": {
+                  "version": "8.10.66",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+                  "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+                },
+                "async": {
+                  "version": "2.6.3",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                  "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                  "requires": {
+                    "lodash": "^4.17.14"
+                  }
+                }
+              }
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+            },
+            "axios": {
+              "version": "0.21.1",
+              "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+              "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+              "requires": {
+                "follow-redirects": "^1.10.0"
+              }
+            },
+            "buffer-equal-constant-time": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+              "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            },
+            "combined-stream": {
+              "version": "1.0.8",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+              "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            },
+            "date-utils": {
+              "version": "1.2.21",
+              "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+              "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+            },
+            "ecdsa-sig-formatter": {
+              "version": "1.0.11",
+              "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+              "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "follow-redirects": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+              "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+            },
+            "form-data": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+              "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+              }
+            },
+            "jwa": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+              "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+              "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "jws": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+              "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+              "requires": {
+                "jwa": "^1.4.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "lodash": {
+              "version": "4.17.21",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            },
+            "mime-db": {
+              "version": "1.48.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+              "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+            },
+            "mime-types": {
+              "version": "2.1.31",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+              "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+              "requires": {
+                "mime-db": "1.48.0"
+              }
+            },
+            "node-fetch": {
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+              "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+            },
+            "safe-buffer": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+            },
+            "underscore": {
+              "version": "1.13.1",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+              "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+            },
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            },
+            "xmldom": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+              "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
+            },
+            "xpath.js": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+              "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "mime-db": {
+          "version": "1.43.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.26",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "requires": {
+            "mime-db": "1.43.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "url-join": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1353,53 +2151,30 @@
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "optional": true,
-      "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
     "browser-request": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-      "integrity": "sha512-YyNI4qJJ+piQG6MMEuo7J3Bzaqssufx04zpEKYfSrl/1Op59HWali9zMtBpXnkmqMcOuWJPZvudrm9wISmnCbg=="
+      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
     },
     "btoa": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
       "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-indexof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
+      "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow="
     },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-    },
-    "bytestreamjs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-1.1.3.tgz",
-      "integrity": "sha512-JDGoiJ+yt+4Ui1e/vMWx5TRvmnErBBbsOkprXgbe1fRp2XZzI8MoknoiR/ZVCya9aWJbOhrJ5Heon1wrAdftkg=="
     },
     "call-bind": {
       "version": "1.0.5",
@@ -1414,36 +2189,38 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
-    },
-    "chardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.6.0.tgz",
-      "integrity": "sha512-+QOTw3otC4+FxdjK9RopGpNOglADbr4WPFi0SonkO99JbpkTPbMxmdm4NenhF5Zs+4gPXLI1+y2uazws5TMe8w=="
     },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chrono-node": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.4.8.tgz",
-      "integrity": "sha512-WwfW4/+i1e6tHx5opw/VCfxXnai12/tT5GK+wSHwKtdb0ZkAoxRGIfL8IzuFr/JEQTw4DxevysyX6+YbZSRKLQ==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.11.tgz",
+      "integrity": "sha1-uGomt+MVftzE/jN04bb5DK7cjjk=",
       "requires": {
-        "dayjs": "^1.8.19"
+        "moment": "2.21.0"
       }
     },
     "cli-table": {
@@ -1467,7 +2244,19 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        }
       }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coffee-register": {
       "version": "1.0.0",
@@ -1478,6 +2267,13 @@
         "coffee-script": "^1.12.5",
         "fs-jetpack": "^0.13.3",
         "md5": "^2.2.1"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.12.7",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+          "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+        }
       }
     },
     "coffee-script": {
@@ -1485,44 +2281,28 @@
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "optional": true,
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "optional": true
+    "coffeescript": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="
     },
     "colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw=="
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "version": "1.0.6",
+      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "compare-versions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
-      "optional": true
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1547,6 +2327,13 @@
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "requires": {
         "safe-buffer": "5.2.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "content-type": {
@@ -1567,22 +2354,22 @@
     "core-decorators": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
-      "integrity": "sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA=="
+      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
     },
     "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "requires": {
         "lru-cache": "^4.0.1",
         "which": "^1.2.9"
@@ -1591,14 +2378,24 @@
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "2.x.x"
+        "boom": "5.x.x"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        }
       }
     },
     "crypto": {
@@ -1607,73 +2404,45 @@
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
     },
     "ctype": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha512-T6CEkoSV4q50zW3TlTHMbzy1E5+zlnNcY+yb7tWVYlTwPhx9LpnfAkd4wecpWknDyptp4k97LUZeInlf6jdzBg=="
+      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
     },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA=="
     },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      },
-      "dependencies": {
-        "type": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-        }
-      }
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
-    "dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
-    },
     "ddp.js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ddp.js/-/ddp.js-0.5.0.tgz",
-      "integrity": "sha512-jDsrOfTusxHLrUTZt6q/WeZk90TEcVRKTY5uIHJ1zu1Z65eXfrl6DvUdgf1JdwkYeCaSUvuAXKEkDNsxDQiJhQ=="
+      "integrity": "sha1-+XfuQgeDhXEgO/eB2vtXHQrr1mo="
     },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
       }
     },
     "deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "define-data-property": {
       "version": "1.1.1",
@@ -1688,7 +2457,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -1705,38 +2474,24 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ=="
-    },
     "duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-    },
-    "duration": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
-      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.46"
-      }
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1758,48 +2513,26 @@
       "requires": {
         "esprima": "^4.0.0",
         "through": "~2.3.4"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "requires": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        }
       }
     },
     "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha1-2m0NVpLvtGHggsFIF/4kJ9j10FQ="
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
       }
     },
     "escape-html": {
@@ -1810,64 +2543,39 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha512-yhi5S+mNTOuRvyW4gWlg5W1byMaQGWWSYHXsuFZ7GBo7tpyOwi2EdzMP/QWxh9hwkD2m+wDVHJsxhRIj+v/b/A==",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "requires": {
         "esprima": "^2.7.1",
         "estraverse": "^1.9.1",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.2.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A=="
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
       }
     },
     "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
     "estraverse": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA=="
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
     },
     "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -1877,72 +2585,17 @@
     "eventsource": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-      "integrity": "sha512-bbB5tEuvC+SuRUG64X8ghvjgiRniuA4WlehWbFnoN4z6TxDXpyX+BMHF7rMgZAqoe+EbyNRUbHN0uuP9phy5jQ==",
+      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
         "original": ">=0.0.5"
       }
     },
-    "exifr": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/exifr/-/exifr-5.0.6.tgz",
-      "integrity": "sha512-iDB4IhKoKVF+uDDrHRlyNxWqGaTxYluVWqvBWVG54HkQZe8qkFYl9eQrjEP3d8Q4UMBZ9rWu3Pa+mfC+o4CZuw=="
-    },
-    "expo-modules-autolinking": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-0.0.3.tgz",
-      "integrity": "sha512-azkCRYj/DxbK4udDuDxA9beYzQTwpJ5a9QA0bBgha2jHtWdFGF4ZZWSY+zNA5mtU3KqzYt8jWHfoqgSvKyu1Aw==",
-      "optional": true,
+    "exif": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/exif/-/exif-0.6.0.tgz",
+      "integrity": "sha1-YKYmaAdlQst+T1cZnUrG830sX0o=",
       "requires": {
-        "chalk": "^4.1.0",
-        "commander": "^7.2.0",
-        "fast-glob": "^3.2.5",
-        "find-up": "~5.0.0",
-        "fs-extra": "^9.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-          "optional": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "expo-random": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-13.4.0.tgz",
-      "integrity": "sha512-Z/Bbd+1MbkK8/4ukspgA3oMlcu0q3YTCu//7q2xHwy35huN6WCv4/Uw2OGyCiOQjAbU02zwq6swA+VgVmJRCEw==",
-      "optional": true,
-      "requires": {
-        "base64-js": "^1.3.0"
+        "debug": "^2.2"
       }
     },
     "express": {
@@ -2000,6 +2653,11 @@
             "toidentifier": "1.0.1"
           }
         },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
         "on-finished": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2015,6 +2673,11 @@
           "requires": {
             "side-channel": "^1.0.4"
           }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "setprototypeof": {
           "version": "1.2.0",
@@ -2041,18 +2704,10 @@
         "basic-auth": "^2.0.1"
       }
     },
-    "ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "requires": {
-        "type": "^2.7.2"
-      }
-    },
     "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -2065,41 +2720,19 @@
       "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ=="
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "optional": true,
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    },
-    "fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "optional": true,
-      "requires": {
-        "reusify": "^1.0.4"
-      }
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "faye-websocket": {
       "version": "0.11.4",
@@ -2110,23 +2743,9 @@
       }
     },
     "file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "requires": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      }
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "optional": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -2160,22 +2779,12 @@
     "find-root": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
-      "integrity": "sha512-GyDxVgA61TZcrgDJPqOqGBpi80Uf2yIstubgizi7AjC9yPdRrqBR+Y0MvK4kXnYlaoz3d+SGxDHMYVkwI/yd2w=="
-    },
-    "find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "optional": true,
-      "requires": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      }
+      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
     },
     "flowdock": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/flowdock/-/flowdock-0.9.1.tgz",
-      "integrity": "sha512-LfV+jSycydZzfgKsnoLvAg4bQgsazctECUb+O/qr4LYtCjy0Ep4cZ5JIkBSR4qlB0yx5889tLkSh5csgQ4So9w==",
+      "integrity": "sha1-R0cMDfxpqVU3S21kRHPlD+djpng=",
       "requires": {
         "buffer-indexof": "^1.0.0",
         "request": "~2.58.0"
@@ -2184,40 +2793,56 @@
         "asn1": {
           "version": "0.1.11",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "integrity": "sha512-Fh9zh3G2mZ8qM/kwsiKwL2U2FmXxVsboP4x1mXjnhKHv3SmzaBZoYvxEQJz/YS2gnCgd8xlAVWcZnQyC9qZBsA=="
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
         },
         "assert-plus": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-          "integrity": "sha512-brU24g7ryhRwGCI2y+1dGQmQXiZF7TtIj583S96y0jjdajIe6wn8BuXyELYhvD22dtIxDQVFk04YTJwwdwOYJw=="
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
         },
         "async": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.14"
+            "lodash": "^4.17.10"
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "integrity": "sha512-oqUX0DM5j7aPWPCnpWebiyNIj2wiNI87ZxnOMoGv0aE4TGlBy2N+5iWc6dQ/NOKZaBD2W6PVz8jtOGkWzSC5EA=="
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.x.x"
+          }
         },
         "caseless": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
-          "integrity": "sha512-1meZDjkziCX2rIL72FnjndyP96yCOfKhkmzr8Umi0xOw493PlVoOgfOmjScp9YaFJU1Acpwe9zeHBMVH5p4xPA=="
+          "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk="
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.x.x"
+          }
         },
         "extend": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
-          "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
+          "integrity": "sha1-G3SYVAAXG4VVSJRFnJeN5u9FOrc="
         },
         "form-data": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "integrity": "sha512-M4Yhq2mLogpCtpUmfopFlTTuIe6mSCTgKvnlMhDj3NcgVhA1uS20jT0n+xunKPzpmL5w2erSVtp+SKiJf1TlWg==",
+          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
           "requires": {
             "async": "^2.0.1",
             "combined-stream": "^1.0.5",
@@ -2225,19 +2850,19 @@
           },
           "dependencies": {
             "mime-types": {
-              "version": "2.1.35",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-              "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+              "version": "2.1.21",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+              "integrity": "sha1-KJlaoey3cHQv5q5+WPkYHHRLP5Y=",
               "requires": {
-                "mime-db": "1.52.0"
+                "mime-db": "~1.37.0"
               }
             }
           }
         },
         "har-validator": {
           "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-          "integrity": "sha512-0+M2lRG5aXVEFwZZ2tUeRVBZT5AxViug9y94qquvQaHHVoL9ydL86aJvI3K28rwoD+DL15DzAgWtPCXNhdTKAQ==",
+          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
           "requires": {
             "bluebird": "^2.9.30",
             "chalk": "^1.0.0",
@@ -2245,50 +2870,61 @@
             "is-my-json-valid": "^2.12.0"
           }
         },
+        "hawk": {
+          "version": "2.3.1",
+          "resolved": "http://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
         "http-signature": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-          "integrity": "sha512-Cg0qO4VID3bADaSsfFIh4X0UqktZKlKWM4tRpa2836Xka0U11xGMnX1AQBPyEkzTLc1KDqiQ8UmNB2qRYHe3SQ==",
+          "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
           "requires": {
             "asn1": "0.1.11",
             "assert-plus": "^0.1.5",
             "ctype": "0.5.3"
           }
         },
+        "mime-db": {
+          "version": "1.37.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+          "integrity": "sha1-C2oM5v2+lXbiXx8tL96IMNwK0Ng="
+        },
         "mime-types": {
           "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "integrity": "sha512-2ZHUEstNkIf2oTWgtODr6X0Cc4Ns/RN/hktdozndiEhhAC2wxXejF1FH0XLHTEImE9h6gr/tcnr3YOnSGsxc7Q==",
+          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "requires": {
             "mime-db": "~1.12.0"
           },
           "dependencies": {
             "mime-db": {
               "version": "1.12.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-              "integrity": "sha512-5aMAW7I4jZoZB27fXRuekqc4DVvJ7+hM8UcWrNj2mqibE54gXgPSonBYBdQW5hyaVNGmiYjY0ZMqn9fBefWYvA=="
+              "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+              "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
             }
           }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA=="
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha512-VlF07iu3VV3+BTXj43Nmp6Irt/G7j/NgEctUS6IweH1RGhURjjCc2NWtzXFPXXWWfc7hgbXQdtiQu2LGp6MxUg=="
         },
         "qs": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-          "integrity": "sha512-nR5uYqNsm8CgBhfCpsYKz6iDhvKjf0xdFT4KanNlLP40COGwZEsjbLoDyL9VrTXyiICUGUbsiN3gBpLGZhSZWQ=="
+          "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw="
         },
         "request": {
           "version": "2.58.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
-          "integrity": "sha512-okf2uk5kTQKSr+xClLCKA6jGH+ekhV1TfzS7eGiR0u2+ozO2uOSwFUlBZ8xx7C8Oula36UfTaYGxqs4VRpaPRw==",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.58.0.tgz",
+          "integrity": "sha1-tfScC5Sqt/rTiGEqH7atA7bMFYA=",
           "requires": {
             "aws-sign2": "~0.5.0",
             "bl": "~0.9.0",
@@ -2311,30 +2947,38 @@
             "tunnel-agent": "~0.4.0"
           }
         },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
         "tunnel-agent": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha512-e0IoVDWx8SDHc/hwFTqJDQ7CCDTEeGhmcT9jkWJjoGQSpgBz20nAMr80E3Tpk7PatJ1b37DQDgJR3CNSzcMOZQ=="
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
+        "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -2348,22 +2992,10 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
-    "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "optional": true,
-      "requires": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
     "fs-jetpack": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-0.13.3.tgz",
-      "integrity": "sha512-PeSnC/SG2dnXPbV9wefudQSdGpVPCf+Vh1XidOlEXyYFgJ+UeWkWkG7GH8pUgs1VxRK1OeJ6dXzX6KQTM+ZE5w==",
+      "integrity": "sha1-nmxHEY8Ls9iAzIj5+KfSWGP0+xU=",
       "requires": {
         "minimatch": "^3.0.2"
       }
@@ -2376,7 +3008,7 @@
     "generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
       "requires": {
         "is-property": "^1.0.2"
       }
@@ -2384,7 +3016,7 @@
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
         "is-property": "^1.0.0"
       }
@@ -2403,7 +3035,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2411,22 +3043,13 @@
     "glob": {
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "requires": {
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "2 || 3",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "optional": true,
-      "requires": {
-        "is-glob": "^4.0.1"
       }
     },
     "global": {
@@ -2439,9 +3062,9 @@
       }
     },
     "gm": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/gm/-/gm-1.25.0.tgz",
-      "integrity": "sha512-4kKdWXTtgQ4biIo7hZA396HT062nDVVHPjQcurNZ3o/voYN+o5FUC5kOwuORbpExp3XbTJ3SU7iRipiIhQtovw==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
+      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
       "requires": {
         "array-parallel": "~0.1.3",
         "array-series": "~0.1.5",
@@ -2456,6 +3079,11 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -2467,24 +3095,25 @@
         "get-intrinsic": "^1.1.3"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "optional": true
-    },
     "handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.14.tgz",
+      "integrity": "sha512-E7tDoyAA8ilZIV3xDJgl18sX3M8xB9/fMw8+mfW4msLW8jlX97bAnWgT3pmaNXuvzIEgSBMnAHfuXsB2hdzfow==",
       "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2495,30 +3124,29 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^6.12.3",
+        "ajv": "^5.1.0",
         "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "optional": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
     "has-property-descriptors": {
       "version": "1.0.1",
@@ -2547,20 +3175,20 @@
       }
     },
     "hawk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-      "integrity": "sha512-Pnn5Bomr1ypnBHCwhsnj+5zhP3nel9ZPa9wdzFoanaN5+1/g5dtDfBZVVZR112sfYiAftUTFczmiWGkuG0SkSQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
     },
     "http-errors": {
       "version": "1.7.3",
@@ -2572,17 +3200,24 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "http-parser-js": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
-      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.6.tgz",
+      "integrity": "sha1-GVJz9YcExFLWcQdr4gEyndNB3FU="
     },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -2590,26 +3225,26 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "requires": {
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -2632,11 +3267,6 @@
           "version": "3.2.5",
           "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
           "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
-        },
-        "coffeescript": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
-          "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="
         }
       }
     },
@@ -2652,12 +3282,12 @@
     "hubot-diagnostics": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/hubot-diagnostics/-/hubot-diagnostics-0.0.2.tgz",
-      "integrity": "sha512-q0Tokqy1XZ9XMBRuNpXK3nROFn7oiiCD+9bjMwco8k7Ny3M0SlnzVnGwTDztMgln6C3IG+26h4fKCAhGPQZL5A=="
+      "integrity": "sha1-oEKyzcn9jwFYPhBWWBMKbYua84Y="
     },
     "hubot-flowdock": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/hubot-flowdock/-/hubot-flowdock-0.7.8.tgz",
-      "integrity": "sha512-YIr+qG3qKIhsX5Lj2mI/YRy0P403oka7FkkRsAaFbkM8n4w+rYuZRizPYw7hE7VVbjJ+/awYCh9/DZ+ZQ6nv/g==",
+      "integrity": "sha1-gQHVQsujI+yENwEuEPKFNpYO+dk=",
       "requires": {
         "flowdock": "^0.9.1",
         "parent-require": "^1.0.0"
@@ -2666,37 +3296,68 @@
     "hubot-help": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/hubot-help/-/hubot-help-0.2.2.tgz",
-      "integrity": "sha512-GYEHWl+3/BV5PRI3TcmHdCa3YcmPXuUMWgnrVn4gpdRNKOqyVu2zrF7DtDn7dICuogILUDjQusN9KHjaT3TOWg=="
+      "integrity": "sha1-zqF+eCzndrdD9lOTk1s0MMLoGXw="
     },
     "hubot-irc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.2.tgz",
-      "integrity": "sha512-Dj/v9WElKYEm/9iBpYf1yidGe5WPpe8Ir2tWccc3vGLv7B3DbJ5JJIqfBRpK4P6LbuBZfdirCBHS5ALaWNItmg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.0.tgz",
+      "integrity": "sha1-qV1cMshnAtljJOgnZWrUV65fT1o=",
       "requires": {
-        "irc": "github:matrix-org/node-irc",
+        "irc": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
         "log": "1.4.0"
       }
     },
     "hubot-matteruser": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.4.6.tgz",
-      "integrity": "sha512-G6zo19ODGrG2cz6458U+He3fdG1I/bSa0x+SI6HZjB429d5fKMkSkqGIdscLs5j1fs4nYH+9oGkhIrODMv5E7A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.2.0.tgz",
+      "integrity": "sha1-YeDZDemcwS4QC5HpyTJGPSggZl0=",
       "requires": {
-        "mattermost-client": "^6.5.0"
+        "mattermost-client": "^6.1.0",
+        "parent-require": "^1.0.0",
+        "q": "^1.4.1"
       }
     },
     "hubot-redis-brain": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/hubot-redis-brain/-/hubot-redis-brain-0.0.4.tgz",
-      "integrity": "sha512-E8gW2WI6El+LB/tstf6LaCveMkn15KJrgl2jONdR6ehE4Mzw1PzYzBWdA4pte1mmM2LHW/CyxlH8yXO08thiRA==",
+      "integrity": "sha1-kYLFd1YAZbNKBaLqHdq6Ix0JMCM=",
       "requires": {
         "redis": "~2.6.x"
+      },
+      "dependencies": {
+        "redis": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
+          "integrity": "sha1-h8Hv9KSJ+Utwhx89CLaYjyOpVoc=",
+          "requires": {
+            "double-ended-queue": "^2.1.0-0",
+            "redis-commands": "^1.2.0",
+            "redis-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            },
+            "redis-commands": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+              "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
+            },
+            "redis-parser": {
+              "version": "2.6.0",
+              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+              "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+            }
+          }
+        }
       }
     },
     "hubot-rocketchat": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hubot-rocketchat/-/hubot-rocketchat-2.0.0.tgz",
-      "integrity": "sha512-p6vThyU9iLwy2o5vY6yJg4KZrOHVCtxJp/ZCAcWVs1NV/+VEwvtvrWf4Z+G8Xcxgxuxked0wpue7oRVTk6RbZw==",
+      "integrity": "sha1-0a3p8ULBseB9/SeIgAUTP5ajOqU=",
       "requires": {
         "@rocket.chat/sdk": "^0.1.0",
         "hubot": "3"
@@ -2705,7 +3366,7 @@
     "hubot-scripts": {
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/hubot-scripts/-/hubot-scripts-2.17.2.tgz",
-      "integrity": "sha512-OP3sVSuYUZEjcJZfT0dh1YVkg/lPiPUV5InhY2b22Sr69L7qZdheZ7KT6YCghGmBKeUcMjVSb/O0Iqnio7H7Sg==",
+      "integrity": "sha1-mwjpB9XPq6cteDIEBnp4zp3zriQ=",
       "requires": {
         "redis": "0.8.4"
       },
@@ -2713,7 +3374,7 @@
         "redis": {
           "version": "0.8.4",
           "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.4.tgz",
-          "integrity": "sha512-qCA0YGVb1C3HCuCv6FO4NAiIK/k5wG6JIMBdixJxcQf9wLGjV4eF8K50r5lwy49lTi8PH/q9aqQ5RsV7patQzQ=="
+          "integrity": "sha1-FGCfJkFOIRwx480H3HmwS/n/GYA="
         }
       }
     },
@@ -2752,7 +3413,7 @@
         "request": {
           "version": "2.9.3",
           "resolved": "https://registry.npmjs.org/request/-/request-2.9.3.tgz",
-          "integrity": "sha512-SyyCqkxodKeOkoQqbLfLnwSGmVP/HXI3/CedADYEzH0Txml8P1p2XNyhfCJR9ejk8yqPMftdeYXH9+Oi0liX6Q=="
+          "integrity": "sha1-rArCYWlWiDfSiGqSsiwL0eFeetc="
         }
       }
     },
@@ -2772,9 +3433,9 @@
       }
     },
     "hubot-xmpp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/hubot-xmpp/-/hubot-xmpp-0.2.6.tgz",
-      "integrity": "sha512-JqByL+unUz0WZYp0Miovr7iiHwkgISJLMiL9FBEdovYZwsSmZegixyqm0y5L7bIklz57J2oIs/jrY0DitKCt/A==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/hubot-xmpp/-/hubot-xmpp-0.2.5.tgz",
+      "integrity": "sha1-/8PfqqejTVSz2SPqcWcRLErcnB0=",
       "requires": {
         "node-xmpp-client": "3.0.0",
         "uuid": "2.0.2"
@@ -2782,9 +3443,18 @@
       "dependencies": {
         "uuid": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-          "integrity": "sha512-BooSif/UQWXwaQme+4z32duvmtUUz/nlHsyGrrSCgsGf6snMrp9q/n1nGHwQzU12kaCeceODmAiRZA8TCK06jA=="
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+          "integrity": "sha1-SL1WmPBnfjx5AaHEbvFbFkN5RyY="
         }
+      }
+    },
+    "iconv": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.2.3.tgz",
+      "integrity": "sha1-4ITWDut9c9p/CpwJbkyKvgkL+u0=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.3.5"
       }
     },
     "iconv-lite": {
@@ -2795,38 +3465,19 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "optional": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "ip-anonymize": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ip-anonymize/-/ip-anonymize-0.1.0.tgz",
-      "integrity": "sha512-cZJu+N5JKKFGMK0eEQWNaQMn2EhCysciVM6eotCJwfqotj16BTfVchKsJCH6mQAT9N0GC7oWRcsZ6Lb8dDiwTA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -2834,72 +3485,45 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "irc": {
-      "version": "github:matrix-org/node-irc#b684a46d11a9f0045f237d423bb83eb78b4eec39",
-      "from": "github:matrix-org/node-irc",
+      "version": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
+      "from": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
       "requires": {
-        "chardet": "^1.5.1",
-        "iconv-lite": "^0.6.3",
-        "typed-emitter": "^2.1.0",
-        "utf-8-validate": "^6.0.3"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
+        "iconv": "~2.2.1",
+        "irc-colors": "^1.1.0",
+        "node-icu-charset-detector": "~0.2.0"
       }
+    },
+    "irc-colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.5.0.tgz",
+      "integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "optional": true
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "optional": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-my-ip-valid": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
-      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ="
     },
     "is-my-json-valid": {
-      "version": "2.20.6",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
-      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha1-j9bkA2PNBrlj+od9REv7Xt3GIXU=",
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
         "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^5.0.0",
+        "jsonpointer": "^4.0.0",
         "xtend": "^4.0.0"
       }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "optional": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -2909,68 +3533,45 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-primitive": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
-      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w=="
-    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
-    },
-    "isomorphic-webcrypto": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/isomorphic-webcrypto/-/isomorphic-webcrypto-2.3.8.tgz",
-      "integrity": "sha512-XddQSI0WYlSCjxtm1AI8kWQOulf7hAN3k3DclF1sxDJZqOe0pcsOt675zvWW91cZH9hYs3nlA3Ev8QK5i80SxQ==",
-      "requires": {
-        "@peculiar/webcrypto": "^1.0.22",
-        "@unimodules/core": "*",
-        "@unimodules/react-native-adapter": "*",
-        "asmcrypto.js": "^0.22.0",
-        "b64-lite": "^1.3.1",
-        "b64u-lite": "^1.0.1",
-        "expo-random": "*",
-        "msrcrypto": "^1.5.6",
-        "react-native-securerandom": "^0.1.1",
-        "str2buf": "^1.3.0",
-        "webcrypto-shim": "^0.1.4"
-      }
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha512-nMtdn4hvK0HjUlzr1DrKSUY8ychprt8dzHOgY2KXsIhHu5PuQQEOTM27gV9Xblyon7aUH/TSFIjRHEODF/FRPg==",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "requires": {
         "abbrev": "1.0.x",
         "async": "1.x",
@@ -2986,26 +3587,6 @@
         "supports-color": "^3.1.0",
         "which": "^1.1.1",
         "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A=="
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA=="
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
       }
     },
     "javascript-state-machine": {
@@ -3013,25 +3594,27 @@
       "resolved": "https://registry.npmjs.org/javascript-state-machine/-/javascript-state-machine-3.1.0.tgz",
       "integrity": "sha512-BwhYxQ1OPenBPXC735RgfB+ZUG8H3kjsx8hrYTgWnoy6TPipEy4fiicyhT2lxRKAXq9pG7CfFT8a2HLr6Hmwxg=="
     },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "optional": true
-    },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+        }
       }
     },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
     },
     "json-schema": {
       "version": "0.4.0",
@@ -3039,34 +3622,24 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
-      }
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonpointer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -3078,6 +3651,13 @@
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+        }
       }
     },
     "jsprim": {
@@ -3094,7 +3674,7 @@
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3104,7 +3684,7 @@
     "jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -3113,29 +3693,15 @@
     "key-tree-store": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/key-tree-store/-/key-tree-store-1.3.0.tgz",
-      "integrity": "sha512-qXk+lR+LXvGos3wqMxIMWweKDgCx8ZKWM6BEPm7iZkOKug5ggi66vUt+3vbtKJLBrAyOxQ4S8JRwK++Q4XZRmw=="
-    },
-    "kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+      "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "optional": true,
-      "requires": {
-        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -3146,17 +3712,17 @@
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A=="
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ=="
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "requires": {
         "lodash._basecopy": "^3.0.0",
         "lodash.keys": "^3.0.0"
@@ -3165,7 +3731,7 @@
     "lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
+      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "requires": {
         "lodash._arraycopy": "^3.0.0",
         "lodash._arrayeach": "^3.0.0",
@@ -3178,22 +3744,22 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ=="
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
     },
     "lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A=="
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ=="
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
     },
     "lodash._createassigner": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha512-LziVL7IDnJjQeeV95Wvhw6G28Z8Q6da87LWKOPWmzBLv4u6FAT/x5v00pyGW0u38UoogNF2JnD3bGgZZDaNEBw==",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "requires": {
         "lodash._bindcallback": "^3.0.0",
         "lodash._isiterateecall": "^3.0.0",
@@ -3203,17 +3769,17 @@
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA=="
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ=="
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
     },
     "lodash.assign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha512-/VVxzgGBmbphasTg51FrztxQJ/VgAUpol6zmJuSVSGcNg4g7FA4z7rQV8Ovr9V3vFBNWZhvKWHfpAytjTVUfFA==",
+      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
       "requires": {
         "lodash._baseassign": "^3.0.0",
         "lodash._createassigner": "^3.0.0",
@@ -3221,158 +3787,166 @@
       }
     },
     "lodash.clone": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
-      "integrity": "sha512-yVYPpFTdZDCLG2p07gVRTvcwN5X04oj2hu4gG6r0fer58JA08wAVxXzWM+CmmxO2bzOH8u8BkZTZqgX6juVF7A==",
-      "requires": {
-        "lodash._baseclone": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
-      }
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
+      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
       "requires": {
         "lodash._baseclone": "^3.0.0",
         "lodash._bindcallback": "^3.0.0"
       }
     },
+    "lodash.fill": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.fill/-/lodash.fill-3.4.0.tgz",
+      "integrity": "sha1-o8dK5kDQU63w3CB5+HIHiOi/74U="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.intersection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
+      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ=="
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
         "lodash._getnative": "^3.0.0",
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.partialright": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+      "integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw=="
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
-      "integrity": "sha512-NnLhcxIAbhdhuMU0jDG83YjAH8JQj8tXUTy54Ib+4owuXwerrYFI8+OsnK1Ez/cig8O859QK6u6g0aYph/X/zQ=="
+      "resolved": "http://registry.npmjs.org/log/-/log-1.4.0.tgz",
+      "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
     "long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "optional": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
     },
     "ltx": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.10.0.tgz",
-      "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
+      "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
       "requires": {
-        "inherits": "^2.0.4"
+        "inherits": "^2.0.1"
       }
     },
     "mattermost-client": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.5.0.tgz",
-      "integrity": "sha512-4Nqg8k3lF/Mr5DGt3s0cZfNm+hF/YTKaIDVQJNGuB0TiaE7/BSJMcpwKdoBjz4ztruWNaV+oBAofrUILwT1EcA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.1.0.tgz",
+      "integrity": "sha1-cw5BLw8BTvq2GiHbKN8S8gqIgSY=",
       "requires": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "log": "^6.1.0",
-        "request": "^2.88.0",
-        "set-value": ">=4.0.1",
-        "text-encoding": "^0.7.0",
-        "ws": ">=3.3.1"
-      },
-      "dependencies": {
-        "log": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
-          "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
-          "requires": {
-            "d": "^1.0.1",
-            "duration": "^0.2.2",
-            "es5-ext": "^0.10.53",
-            "event-emitter": "^0.3.5",
-            "sprintf-kit": "^2.0.1",
-            "type": "^2.5.0",
-            "uni-global": "^1.0.0"
-          }
-        }
+        "https-proxy-agent": "^2.1.0",
+        "log": "^1.4.0",
+        "request": "^2.73.0",
+        "text-encoding": "^0.5.5",
+        "ws": "^1.0.1"
       }
     },
     "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "media-typer": {
@@ -3385,26 +3959,10 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "optional": true
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
-    },
-    "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "optional": true,
-      "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      }
     },
     "mime": {
       "version": "1.6.0",
@@ -3412,22 +3970,22 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
     },
     "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
       "requires": {
-        "mime-db": "1.52.0"
+        "mime-db": "~1.33.0"
       }
     },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -3441,49 +3999,54 @@
       }
     },
     "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
-        "minimist": "^1.2.6"
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha1-KhFLUdKm7J5tg8+AP4OKh42KAjo="
     },
     "ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "ms-rest": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.6.tgz",
-      "integrity": "sha512-3Scy/pF43wqPEPeJxhOsLs16m6Rt+9zqf+jKdg+guuonytKmFSxerQM2exlQIDTqFVTsLXrPEGFWTGSwivRRkA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.4.tgz",
+      "integrity": "sha512-VeqCbawxRM6nhw0RKNfj7TWL7SL8PB6MypqwgylXCi+u412uvYoyY/kSmO8n06wyd8nIcnTbYToCmSKFMI1mCg==",
       "requires": {
-        "ajv": "6.12.3",
         "duplexer": "^0.1.1",
-        "http-signature": "1.3.6",
         "is-buffer": "^1.1.6",
         "is-stream": "^1.1.0",
         "moment": "^2.21.0",
-        "request": "^2.88.2",
+        "request": "^2.88.0",
         "through": "^2.3.8",
         "tunnel": "0.0.5",
         "uuid": "^3.2.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -3491,33 +4054,102 @@
             "uri-js": "^4.2.2"
           }
         },
-        "http-signature": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-          "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+        "aws4": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^2.0.2",
-            "sshpk": "^1.14.1"
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
           }
         },
-        "jsprim": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
-          "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "mime-db": {
+          "version": "1.43.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.26",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
           "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.4.0",
-            "verror": "1.10.0"
+            "mime-db": "1.43.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
           }
         }
       }
-    },
-    "msrcrypto": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/msrcrypto/-/msrcrypto-1.5.8.tgz",
-      "integrity": "sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q=="
     },
     "multiparty": {
       "version": "4.2.3",
@@ -3541,6 +4173,16 @@
             "toidentifier": "1.0.1"
           }
         },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
         "setprototypeof": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -3553,99 +4195,130 @@
         }
       }
     },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
+    },
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
     "node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
-    "node-gyp-build": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.0.tgz",
-      "integrity": "sha512-PbZERfeFdrHQOOXiAKOY0VPbykZy90ndPKk0d+CFDegTKmWp1VgOTz2xACVbr1BjCWxrQp68CXtvNsveFhqDJg=="
+    "node-icu-charset-detector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-icu-charset-detector/-/node-icu-charset-detector-0.2.0.tgz",
+      "integrity": "sha1-wjINo3Tdy2cfxUy0oOBB4Vb/1jk=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.3.3"
+      }
     },
     "node-jose": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.2.0.tgz",
-      "integrity": "sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-0.11.1.tgz",
+      "integrity": "sha512-1mX5prmancKdOgMI/85uduqWNFg63traxVdun7dNNsX4AUs6HqztJhzfBlIWfSujQ8Rah9dWLGUFlXORxZvvzg==",
       "requires": {
-        "base64url": "^3.0.1",
-        "buffer": "^6.0.3",
-        "es6-promise": "^4.2.8",
-        "lodash": "^4.17.21",
-        "long": "^5.2.0",
-        "node-forge": "^1.2.1",
-        "pako": "^2.0.4",
-        "process": "^0.11.10",
-        "uuid": "^9.0.0"
+        "b64u": "^2.0.0",
+        "es6-promise": "^4.0.5",
+        "lodash.assign": "^4.0.8",
+        "lodash.clone": "^4.3.2",
+        "lodash.fill": "^3.2.2",
+        "lodash.flatten": "^4.2.0",
+        "lodash.intersection": "^4.1.2",
+        "lodash.merge": "^4.3.5",
+        "lodash.omit": "^4.2.1",
+        "lodash.partialright": "^4.1.3",
+        "lodash.pick": "^4.2.0",
+        "lodash.uniq": "^4.2.1",
+        "long": "^3.1.0",
+        "node-forge": "^0.7.1",
+        "uuid": "^3.0.1"
       },
       "dependencies": {
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        "lodash.assign": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
         }
       }
     },
     "node-kms": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.4.0.tgz",
-      "integrity": "sha512-Tvhs7XTvBgWLZUrAeLKDqzvlomaZWwMoIXWImMc/IbvTijLoOrkovZo+PeW0ivf/8fBlg5EihPCwKg/dy9r+sA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.3.2.tgz",
+      "integrity": "sha1-beflJICO7ATHf+6072SUDlDit1k=",
       "requires": {
         "es6-promise": "^2.0.1",
         "lodash.clone": "^3.0.2",
         "lodash.clonedeep": "^3.0.1",
-        "node-jose": "^2.0.0",
+        "node-jose": ">=0.3.0 <1.0",
         "uuid": "^2.0.1"
       },
       "dependencies": {
         "es6-promise": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
+          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
+        },
+        "lodash.clone": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
+          "requires": {
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
         },
         "uuid": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg=="
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
     },
     "node-scr": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.3.0.tgz",
-      "integrity": "sha512-Hb0ykojynSbt7ra6eml6NX39WAumFfU3G81XvLpp2H7y8KjQc29oEIf2TlgZQCfA+pyxbY5t4a1xBqPpyrbpvw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.2.2.tgz",
+      "integrity": "sha1-VCqtdCAQ0S5Bm1kG2lFq+d6jBdo=",
       "requires": {
         "es6-promise": "^2.0.1",
         "lodash.clone": "^3.0.2",
-        "node-jose": "^2.0.0"
+        "node-jose": ">=0.3.0 <1.0"
       },
       "dependencies": {
         "es6-promise": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
+          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
+        },
+        "lodash.clone": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
+          "requires": {
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
         }
       }
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "node-xmpp-client": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.0.0.tgz",
-      "integrity": "sha512-evWWdIBMx5AzNmj0CkCwlhosRACRTWC4W4rnhUHg1MZPmqfsIl/WPHTwQfwnQE0xL0+EUcVkUJigOzolmHfI9Q==",
+      "integrity": "sha1-UsxdO/fR/IbSd2pYL3x7yugCYTo=",
       "requires": {
         "browser-request": "^0.3.3",
         "debug": "^2.2.0",
@@ -3659,7 +4332,7 @@
         "faye-websocket": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha512-Xhj93RXbMSq8urNCUq4p9l0P6hnySJ/7YNRhYNug0bLOuii7pKO7xQFb5mx9xZXWCar88pLPb805PvUkwrLZpQ==",
+          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
@@ -3669,7 +4342,7 @@
     "node-xmpp-core": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-core/-/node-xmpp-core-4.2.0.tgz",
-      "integrity": "sha512-ZugTIR0OU3Q23b7rcsHzvxfmfjZ7+khQcWm5r+5i1kxrs85eIan2ahsUp2LtSDBzcYk+8CqDgSKh+MYue08oXg==",
+      "integrity": "sha1-fi4EDB5apkvjUBO9w0Ey7Ddpla4=",
       "requires": {
         "debug": "^2.2.0",
         "inherits": "^2.0.1",
@@ -3683,20 +4356,20 @@
     "node-xmpp-jid": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-jid/-/node-xmpp-jid-2.3.0.tgz",
-      "integrity": "sha512-jSmRnpbc0brF9baWg9QZQzhyNNkobGsw0zAymWl0hsIb+CsaPpZboWJ+NGeHq89XwqC6udJjwMiUDZM3tqqFLw=="
+      "integrity": "sha1-YKPJUFgqDNz9oHRJQ1eoUXjziHg="
     },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
         "abbrev": "1"
       }
     },
     "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-inspect": {
       "version": "1.13.1",
@@ -3711,7 +4384,7 @@
     "object.assign": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-1.1.1.tgz",
-      "integrity": "sha512-F69Cy1YWq1KjNDhAhT4vpC5/8MVw5r2IsZC1PrlOVt/d8VtxJC/m9vFrhZwizNKlLfjA61bIpWhHpjHXbBdF0Q==",
+      "integrity": "sha1-8ilnQnP5T8sjDQLBlYqLlOye+Vw=",
       "requires": {
         "object-keys": "~1.0.1"
       }
@@ -3727,28 +4400,49 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
+    },
     "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
+        "fast-levenshtein": "~2.0.4",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "wordwrap": "~1.0.0"
       }
     },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg=="
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "optparse": {
       "version": "1.0.5",
@@ -3763,75 +4457,35 @@
         "url-parse": "^1.4.3"
       }
     },
-    "p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "optional": true,
-      "requires": {
-        "yocto-queue": "^0.1.0"
-      }
-    },
-    "p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "optional": true,
-      "requires": {
-        "p-limit": "^3.0.2"
-      }
-    },
-    "pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
-    },
     "parent-require": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
-      "integrity": "sha512-2MXDNZC4aXdkkap+rBBMv0lUsfJqvX5/2FiYYnfCnorZt3Pk06/IOR5KeaoghgS2w07MLWgjbsnyaq6PdHn2LQ=="
+      "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
     },
     "parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
     },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
-    "path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "optional": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "optional": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pkginfo": {
       "version": "0.4.1",
@@ -3839,14 +4493,9 @@
       "integrity": "sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ=="
     },
     "pkijs": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.4.0.tgz",
-      "integrity": "sha512-cjJP/mYuGyMrjJ49jI04khId5Oufd3nFTUYBzQTIIVNI7/oAWdwXEfpwTF8HELFV/gz+WGYUBHCe3KHWD8rYvg==",
-      "requires": {
-        "asn1js": "^3.0.3",
-        "bytestreamjs": "^1.0.29",
-        "pvutils": "^1.1.3"
-      },
+      "version": "2.1.88",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.1.88.tgz",
+      "integrity": "sha512-R/1VglrBioIx3wdX1/DzEcJDvhJgl5cNsT+Ovex3zWbCwjY2mDUW2Qvj6/kc0S7PDDnijXwHczAVRYscNLhUgQ==",
       "dependencies": {
         "asn1js": {
           "version": "3.0.5",
@@ -3857,28 +4506,46 @@
             "pvutils": "^1.1.3",
             "tslib": "^2.4.0"
           }
+        },
+        "bytestreamjs": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+          "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ=="
+        },
+        "pvtsutils": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+          "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
+        "pvutils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+          "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
-    },
-    "precond": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -3895,51 +4562,40 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ="
     },
     "punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "pvtsutils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
-      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.10.tgz",
+      "integrity": "sha512-8ZKQcxnZKTn+fpDh7wL4yKax5fdl3UJzT8Jv49djZpB/dzPxacyN1Sez90b6YLdOmvIr9vaySJ5gw4aUA1EdSw==",
       "requires": {
-        "tslib": "^2.6.1"
+        "tslib": "^1.10.0"
       }
-    },
-    "pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "optional": true
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -3979,6 +4635,11 @@
             "toidentifier": "1.0.1"
           }
         },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
         "setprototypeof": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -3996,19 +4657,10 @@
         }
       }
     },
-    "react-native-securerandom": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz",
-      "integrity": "sha512-CozcCx0lpBLevxiXEb86kwLRalBCHNjiGPlw3P7Fi27U6ZLdfjOCNRHD1LtBKcvPvI3TvkBXB3GOtLvqaYJLGw==",
-      "optional": true,
-      "requires": {
-        "base64-js": "*"
-      }
-    },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -4016,188 +4668,86 @@
         "string_decoder": "~0.10.x"
       }
     },
-    "readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "requires": {
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
     "reconnect-core": {
       "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
+      "integrity": "sha1-udryrcRbGabMX9LwSPjZQGzs5Jg=",
       "requires": {
         "backoff": "~2.3.0"
-      },
-      "dependencies": {
-        "backoff": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
-          "integrity": "sha512-ljr33cUQ/vyXE/60QuRO+WKGW4PzQ5OTWNXPWQwOTx5gh43q0pZocaVyXoU2gvFtasMIdIohdm9s01qoT6IJBQ=="
-        }
       }
-    },
-    "redis": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
-      "integrity": "sha512-u5pJPYdQX5Oca+nyThh0CJD0fSRyj0Z9ldn9LIEenNdiMZJ5Ut90q12St8ICYLvDsfbLqF0MujyU0c3ZLA06CA==",
-      "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.0.0"
-      }
-    },
-    "redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-    },
-    "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha512-9Hdw19gwXFBJdN8ENUoNVJFRyMDFrE/ZBClPicKYDPwNPJ4ST1TedAHYNSiGKElwh2vrmRGMoJYbVdJd+WQXIw=="
     },
     "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "version": "2.85.0",
+      "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha1-WgNhWkfGFCCz65m326IE+DYD4fo=",
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
+        "aws4": "^1.6.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
+        "uuid": "^3.1.0"
       }
     },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
     },
     "retry": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
       "integrity": "sha512-bkzdIZ5Xyim12j0jq6CQAHpfdsa2VqieWF6eN8vT2MXxCxLAZhgVUyu5EEMevJyXML+XWTxVbZ7mLaKx5F/DZw=="
     },
-    "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "optional": true
-    },
     "rsa-pem-from-mod-exp": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.6.tgz",
-      "integrity": "sha512-c5ouQkOvGHF1qomUUDJGFcXsomeSO2gbEs6hVhMAtlkE1CuaZase/WzoaKFG/EZQuNmq6pw/EMCeEnDvOgCJYQ=="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+      "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
     },
-    "rtcpeerconnection-shim": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
-      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
-      "requires": {
-        "sdp": "^2.6.0"
-      }
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "optional": true,
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "sdp": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
-      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
-    },
     "sdp-transform": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
-      "integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.0.tgz",
+      "integrity": "sha512-8ZYOau/o9PzRhY0aMuRzvmiM6/YVQR8yjnBScvZHSdBnywK5oZzAJK+412ZKkDq29naBmR3bRw8MFu0C01Gehg=="
     },
     "semver": {
       "version": "5.7.2",
@@ -4240,6 +4790,16 @@
             "statuses": "2.0.1",
             "toidentifier": "1.0.1"
           }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "on-finished": {
           "version": "2.4.1",
@@ -4288,15 +4848,6 @@
         "has-property-descriptors": "^1.0.0"
       }
     },
-    "set-value": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
-      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
-      "requires": {
-        "is-plain-object": "^2.0.4",
-        "is-primitive": "^3.0.1"
-      }
-    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -4308,6 +4859,13 @@
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "requires": {
         "kind-of": "^6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        }
       }
     },
     "side-channel": {
@@ -4321,35 +4879,31 @@
       }
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha512-7bgVOAnPj3XjrKY577S+puCKGCRlUrcrEdsMeRXlg9Ghf5df/xNi6sONUa43WrHUd3TjJBF7O04jYoiY0FVa0A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "4.x.x"
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
-    },
-    "sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
-    },
-    "sprintf-kit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
-      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "optional": true,
       "requires": {
-        "es5-ext": "^0.10.53"
+        "amdefine": ">=0.0.4"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4358,7 +4912,6 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
@@ -4383,57 +4936,46 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
     },
-    "str2buf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/str2buf/-/str2buf-1.3.0.tgz",
-      "integrity": "sha512-xIBmHIUHYZDP4HyoXGHYNVmxlXLXDrtFHYT0eV6IOdEj3VO9ccaF1Ejl9Oq8iFjITllpT8FhaXb4KsNmw+3EuA=="
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
     },
-    "strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+    "supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
+        "has-flag": "^1.0.0"
       }
     },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
-    },
     "text-encoding": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.5.5.tgz",
+      "integrity": "sha1-0phF2cHyrFzrpL+GHFYYVsUjrFM="
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
@@ -4442,38 +4984,19 @@
     "tls-connect": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/tls-connect/-/tls-connect-0.2.2.tgz",
-      "integrity": "sha512-iV92SmsU+iB+TZKeZxBRTyk8T0RAXDjpwoYjG28HMm5E0ilPfrfqidDntRL4ZswoqRv81Kx05PqbK6CN7olrKQ=="
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "optional": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
+      "integrity": "sha1-HYjU9MuCmgdBtqzQXR33Pg1Wb9A="
     },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
-    "token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-      "requires": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      }
-    },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "punycode": "^1.4.1"
       }
     },
     "truncate": {
@@ -4484,12 +5007,12 @@
     "tsc": {
       "version": "1.20150623.0",
       "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha512-35dAbChm97r03rxlfPwkFrrI8WoFlrqtbskmxomtnso2fOSKWDLt3TitT2ZNHl5hQF1Su9S9w/vjmoXf5W0VWA=="
+      "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU="
     },
     "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tunnel": {
       "version": "0.0.5",
@@ -4499,7 +5022,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -4507,17 +5030,13 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-    },
-    "type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -4529,20 +5048,27 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
-      }
-    },
-    "typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "requires": {
-        "rxjs": "*"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+          "requires": {
+            "mime-db": "1.52.0"
+          }
+        }
       }
     },
     "uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "version": "3.13.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
+      "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
       "optional": true
     },
     "uid-safe": {
@@ -4556,21 +5082,7 @@
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha512-QMpnpVtYaWEeY+MwKDN/UdKlE/LsFZXM5lO1u7GaZzNgmIbGixHEmVMIKT+vqYOALu3m5GYQy9kz4Xu4IVn7Ow=="
-    },
-    "uni-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
-      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
-      "requires": {
-        "type": "^2.5.0"
-      }
-    },
-    "universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "optional": true
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -4578,17 +5090,24 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "requires": {
         "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+        }
       }
     },
     "url-join": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-      "integrity": "sha512-zz1wZk4Lb5PTVwZ3HWDmm8XnlPvmOof6/fjdDPA5yBrUcbtV64U6bV832Zf1BtU2WkBBWaUT46wCs+l0HP5nhg=="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw=="
     },
     "url-parse": {
       "version": "1.5.10",
@@ -4602,20 +5121,7 @@
     "urlsafe-base64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
-      "integrity": "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="
-    },
-    "utf-8-validate": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.3.tgz",
-      "integrity": "sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==",
-      "requires": {
-        "node-gyp-build": "^4.3.0"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -4623,14 +5129,14 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
     },
     "valid-url": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "vary": {
       "version": "1.1.2",
@@ -4648,79 +5154,57 @@
       }
     },
     "webcrypto-core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.0.19.tgz",
+      "integrity": "sha512-6XHExtfMJrpkFDh9MiJ/y7ptX0dfZi0ogxFyelqxMu1eFowxivHfIp6DKzT+ZjU66xTuNfJkfkUk1bIB3tEOgA==",
       "requires": {
-        "@peculiar/asn1-schema": "^2.3.6",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
+        "@peculiar/asn1-schema": "^1.0.5",
+        "@peculiar/json-schema": "^1.1.10",
+        "asn1js": "^2.0.26",
+        "pvtsutils": "^1.0.10",
+        "tslib": "^1.11.1"
+      }
+    },
+    "webex": {
+      "version": "1.80.178",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-1.80.178.tgz",
+      "integrity": "sha512-DNMYNMPlZqRF1IrwjAmThw2jc7mtV44mz+CzMoH92UGRVYoLaDoO/kxb0nZ8NNiiH99ciUbjnGRNnJ0wa/hX4A==",
+      "requires": {
+        "@webex/internal-plugin-calendar": "1.80.178",
+        "@webex/internal-plugin-device": "1.80.178",
+        "@webex/internal-plugin-presence": "1.80.178",
+        "@webex/plugin-attachment-actions": "1.80.178",
+        "@webex/plugin-authorization": "1.80.178",
+        "@webex/plugin-device-manager": "1.80.178",
+        "@webex/plugin-logger": "1.80.178",
+        "@webex/plugin-meetings": "1.80.178",
+        "@webex/plugin-memberships": "1.80.178",
+        "@webex/plugin-messages": "1.80.178",
+        "@webex/plugin-people": "1.80.178",
+        "@webex/plugin-rooms": "1.80.178",
+        "@webex/plugin-team-memberships": "1.80.178",
+        "@webex/plugin-teams": "1.80.178",
+        "@webex/plugin-webhooks": "1.80.178",
+        "@webex/storage-adapter-local-storage": "1.80.178",
+        "@webex/webex-core": "1.80.178",
+        "babel-polyfill": "^6.26.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.15"
       },
       "dependencies": {
-        "asn1js": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-          "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-          "requires": {
-            "pvtsutils": "^1.3.2",
-            "pvutils": "^1.1.3",
-            "tslib": "^2.4.0"
-          }
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
-    "webcrypto-shim": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
-      "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
-    },
-    "webex": {
-      "version": "1.161.0",
-      "resolved": "https://registry.npmjs.org/webex/-/webex-1.161.0.tgz",
-      "integrity": "sha512-fEheKltkfHrZCNHtZPHZjLPicb47JiKQzKcO/J+26n6snYsLnmhU0y8BHsbWkuudD1RuXZV/kFBSd6/nzWFO4w==",
-      "requires": {
-        "@babel/polyfill": "^7.12.1",
-        "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/internal-plugin-calendar": "1.161.0",
-        "@webex/internal-plugin-device": "1.161.0",
-        "@webex/internal-plugin-presence": "1.161.0",
-        "@webex/internal-plugin-support": "1.161.0",
-        "@webex/plugin-attachment-actions": "1.161.0",
-        "@webex/plugin-authorization": "1.161.0",
-        "@webex/plugin-device-manager": "1.161.0",
-        "@webex/plugin-logger": "1.161.0",
-        "@webex/plugin-meetings": "1.161.0",
-        "@webex/plugin-memberships": "1.161.0",
-        "@webex/plugin-messages": "1.161.0",
-        "@webex/plugin-people": "1.161.0",
-        "@webex/plugin-rooms": "1.161.0",
-        "@webex/plugin-team-memberships": "1.161.0",
-        "@webex/plugin-teams": "1.161.0",
-        "@webex/plugin-webhooks": "1.161.0",
-        "@webex/storage-adapter-local-storage": "1.161.0",
-        "@webex/webex-core": "1.161.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "webrtc-adapter": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
-      "integrity": "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==",
-      "requires": {
-        "rtcpeerconnection-shim": "^1.2.15",
-        "sdp": "^2.12.0"
-      }
-    },
     "websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": ">=0.5.1",
-        "safe-buffer": ">=5.1.0",
+        "http-parser-js": ">=0.4.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
@@ -4730,19 +5214,19 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "requires": {
         "isexe": "^2.0.0"
       }
     },
     "winston": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
-      "integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.6.tgz",
+      "integrity": "sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==",
       "requires": {
-        "async": "^2.6.4",
+        "async": "^3.2.3",
         "colors": "1.0.x",
         "cycle": "1.0.x",
         "eyes": "0.1.x",
@@ -4751,50 +5235,40 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
         }
       }
-    },
-    "word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
     },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha1-y9nm514J/F0skAFfIfDECHXg3VE=",
+      "requires": {
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
+      }
     },
     "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
-    },
-    "yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "optional": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1505,6 +1505,55 @@
         "url-join": "^1.1.0"
       },
       "dependencies": {
+        "@types/node-fetch": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+          "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+          "requires": {
+            "@types/node": "*",
+            "form-data": "^4.0.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "20.9.5",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.5.tgz",
+              "integrity": "sha512-Uq2xbNq0chGg+/WQEU0LJTSs/1nKxz6u1iemLcGomkSnKokbW1fbLqc3HOqCf2JP7KjlL4QkS7oZZTrOQHQYgQ==",
+              "requires": {
+                "undici-types": "~5.26.4"
+              }
+            }
+          }
+        },
+        "@xmldom/xmldom": {
+          "version": "0.8.10",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+          "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
+        },
+        "adal-node": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.4.tgz",
+          "integrity": "sha512-zIcvbwQFKMUtKxxj8YMHeTT1o/TPXfVNsTXVgXD8sxwV6h4AFQgK77dRciGhuEF9/Sdm3UQPJVPc/6XxrccSeA==",
+          "requires": {
+            "@xmldom/xmldom": "^0.8.3",
+            "async": "^2.6.3",
+            "axios": "^0.21.1",
+            "date-utils": "*",
+            "jws": "3.x.x",
+            "underscore": ">= 1.3.1",
+            "uuid": "^3.1.0",
+            "xpath.js": "~1.1.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.4",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+              "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+              "requires": {
+                "lodash": "^4.17.14"
+              }
+            }
+          }
+        },
         "ajv": {
           "version": "6.12.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1516,20 +1565,160 @@
             "uri-js": "^4.2.2"
           }
         },
+        "asn1": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+          "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+        },
         "aws4": {
           "version": "1.12.0",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
           "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+        },
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "buffer-equal-constant-time": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+          "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+        },
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "date-utils": {
+          "version": "1.2.21",
+          "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+          "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA=="
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ecdsa-sig-formatter": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
         },
         "extend": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+        },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+        },
+        "follow-redirects": {
+          "version": "1.15.3",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+          "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
         },
         "har-validator": {
           "version": "5.1.5",
@@ -1540,10 +1729,80 @@
             "har-schema": "^2.0.0"
           }
         },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+        },
+        "json-schema": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+        },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+        },
+        "jsprim": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+          "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.4.0",
+            "verror": "1.10.0"
+          }
+        },
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "mime-db": {
           "version": "1.52.0",
@@ -1558,15 +1817,38 @@
             "mime-db": "1.52.0"
           }
         },
+        "node-fetch": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
         "oauth-sign": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+        },
+        "psl": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+          "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+        },
         "punycode": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
           "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+        },
+        "qs": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
         },
         "request": {
           "version": "2.88.2",
@@ -1593,6 +1875,44 @@
             "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "form-data": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+              "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+              }
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "sshpk": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+          "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
           }
         },
         "tough-cookie": {
@@ -1604,6 +1924,42 @@
             "punycode": "^2.1.1"
           }
         },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+        },
+        "underscore": {
+          "version": "1.13.6",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+          "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+        },
+        "undici-types": {
+          "version": "5.26.5",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+          "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
         "url-join": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
@@ -1613,6 +1969,35 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "verror": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "xpath.js": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+          "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
         }
       }
     },
@@ -1724,11 +2109,6 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
-    },
-    "chardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.6.0.tgz",
-      "integrity": "sha512-+QOTw3otC4+FxdjK9RopGpNOglADbr4WPFi0SonkO99JbpkTPbMxmdm4NenhF5Zs+4gPXLI1+y2uazws5TMe8w=="
     },
     "charenc": {
       "version": "0.0.2",
@@ -3022,11 +3402,11 @@
       "integrity": "sha1-zqF+eCzndrdD9lOTk1s0MMLoGXw="
     },
     "hubot-irc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.2.tgz",
-      "integrity": "sha512-Dj/v9WElKYEm/9iBpYf1yidGe5WPpe8Ir2tWccc3vGLv7B3DbJ5JJIqfBRpK4P6LbuBZfdirCBHS5ALaWNItmg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.0.tgz",
+      "integrity": "sha512-fyK6YKBc/rJnwtWyt6ke92JpxfqdPn8rkl8ArKvhhXLu0SC+UmcLuddNNccLnSte0PbF016fQnZkEGGYbH6uvQ==",
       "requires": {
-        "irc": "github:matrix-org/node-irc",
+        "irc": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
         "log": "1.4.0"
       }
     },
@@ -3169,6 +3549,15 @@
         }
       }
     },
+    "iconv": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.2.3.tgz",
+      "integrity": "sha512-evIiYeKdt5nEGYKNkQcGPQy781sYgbBKi3gEkt1s4CwteCdOHSjGGRyyp6lP8inYFZwvzG3lgjXEvGUC8nqQ5A==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.3.5"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3216,24 +3605,18 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "irc": {
-      "version": "github:matrix-org/node-irc#b684a46d11a9f0045f237d423bb83eb78b4eec39",
-      "from": "github:matrix-org/node-irc",
+      "version": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
+      "from": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
       "requires": {
-        "chardet": "^1.5.1",
-        "iconv-lite": "^0.6.3",
-        "typed-emitter": "^2.1.0",
-        "utf-8-validate": "^6.0.3"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
+        "iconv": "~2.2.1",
+        "irc-colors": "^1.1.0",
+        "node-icu-charset-detector": "~0.2.0"
       }
+    },
+    "irc-colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.5.0.tgz",
+      "integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -4215,6 +4598,12 @@
         }
       }
     },
+    "nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "optional": true
+    },
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -4235,10 +4624,14 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
-    "node-gyp-build": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
-      "integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg=="
+    "node-icu-charset-detector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-icu-charset-detector/-/node-icu-charset-detector-0.2.0.tgz",
+      "integrity": "sha512-DYOFJ3NfKdxEi9hPbmoCss6WydGhJsxpSleUlZfAWEbZt3AU7JuxailgA9tnqQdsHiujfUY9VtDfWD9m0+ThtQ==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.3.3"
+      }
     },
     "node-jose": {
       "version": "2.2.0",
@@ -4822,15 +5215,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -5215,14 +5599,6 @@
         }
       }
     },
-    "typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "requires": {
-        "rxjs": "*"
-      }
-    },
     "uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -5294,14 +5670,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
       "integrity": "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="
-    },
-    "utf-8-validate": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.3.tgz",
-      "integrity": "sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==",
-      "requires": {
-        "node-gyp-build": "^4.3.0"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,6 +4,31 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/polyfill": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.23.4.tgz",
+      "integrity": "sha512-w10wlnER4ZJ60UlxQWiDhaD1nxHrJ3YgGK2V5iws7a07Q1+vQw4eL54kdtuPIadE3LkeG/Xtg+TEI5zWgjYEjw==",
+      "requires": {
+        "core-js": "^2.6.12",
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        }
+      }
+    },
     "@danielkalen/source-map-support": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@danielkalen/source-map-support/-/source-map-support-0.4.16.tgz",
@@ -19,33 +44,72 @@
         }
       }
     },
-    "@peculiar/asn1-schema": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-1.1.2.tgz",
-      "integrity": "sha512-ntQ4UnUFgdjs0tfWR6YmEQm/x0glV4OFus/RjxLkaJUKfu/R7VilefBntyUO3MoKWdlCgib30KN+JpCY1HqU2A==",
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "optional": true,
       "requires": {
-        "asn1js": "^2.0.26",
-        "tslib": "^1.11.1"
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "optional": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "optional": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "asn1js": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+          "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+          "requires": {
+            "pvtsutils": "^1.3.2",
+            "pvutils": "^1.1.3",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@peculiar/json-schema": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.10.tgz",
-      "integrity": "sha512-kbpnG9CkF1y6wwGkW7YtSA+yYK4X5uk4rAwsd1hxiaYE3Hkw2EsGlbGh/COkMLyFf+Fe830BoFiMSB3QnC/ItA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "requires": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.0.0"
       }
     },
     "@peculiar/webcrypto": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.0.27.tgz",
-      "integrity": "sha512-sERMakD19gNhwBVXGGoJjBfc28bDbd2YWaio7/x8jKtvwMKNuljM7ANQ6LzEkEvqFAyjf3bhBZktJ6UXy/0Plg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
       "requires": {
-        "@peculiar/asn1-schema": "^1.0.5",
-        "@peculiar/json-schema": "^1.1.10",
-        "pvtsutils": "^1.0.10",
-        "tslib": "^1.11.1",
-        "webcrypto-core": "^1.0.19-next.0"
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
       }
     },
     "@rocket.chat/sdk": {
@@ -85,69 +149,82 @@
         }
       }
     },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "@types/async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.1.tgz",
-      "integrity": "sha1-Q8Oyxg6rQcJcoACcB8p9YZ2UMRk="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.2.tgz",
+      "integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
     },
     "@types/body-parser": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-      "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g="
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
     },
     "@types/clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-bdkCSkyVHsgl3Goe1y16T9k6JuQx7SiDREkq728QjKmTZkGJZuS8R3gGcnGzVuGBP0mssKrzM/GlMOQxtip9cg=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/clone-deep/-/clone-deep-4.0.4.tgz",
+      "integrity": "sha512-vXh6JuuaAha6sqEbJueYdh5zNBPPgG1OYumuz2UvLvriN6ABHDSW8ludREGWJb1MLIzbwZn4q4zUbUCerJTJfA=="
     },
     "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
-      "integrity": "sha1-11a9GoXDTYfq9EyIi60nuopLfPA=",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.2.tgz",
-      "integrity": "sha1-XuiiLmAgBb5nZ99rLLqYed8/dao=",
+      "version": "4.17.41",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
+      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
       "requires": {
         "@types/node": "*",
-        "@types/range-parser": "*"
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "@types/form-data": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
+      "integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
       "requires": {
-        "@types/node": "*"
+        "form-data": "*"
       }
+    },
+    "@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "@types/jsonwebtoken": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
-      "integrity": "sha1-jRmdq03bW7oyNPgxG4BNICevKzo=",
+      "integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
       "requires": {
         "@types/node": "*"
       }
@@ -158,170 +235,194 @@
       "integrity": "sha1-sth6Xj341LGMpCbFEFzXAcIwbUA="
     },
     "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/node": {
       "version": "9.6.36",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.36.tgz",
       "integrity": "sha1-xKK9sW06ebNOAUZLS9OMG4Se/aw="
     },
+    "@types/qs": {
+      "version": "6.9.10",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
+    },
     "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "@types/request": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
-      "integrity": "sha1-5ALWkapmcPu/8ZV7FfEnAjCrQvo=",
+      "version": "2.48.12",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
+      "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
       "requires": {
         "@types/caseless": "*",
-        "@types/form-data": "*",
         "@types/node": "*",
-        "@types/tough-cookie": "*"
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
       }
     },
     "@types/serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha1-pPy4THNE859w3E7sDh5/EKSFl6M="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.4.tgz",
+      "integrity": "sha512-aWK1reDYWxcjgcIIPmQi3u+OQDuYa9b+lr6eIsGWrekJ9vr1NSjr4Eab8oQ1iKuH1ltFHpXGyerAv1a3FMKxzQ=="
     },
     "@types/tough-cookie": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha1-naRO11VxmZtlw3tgybK4jbVMWF0="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
     "@types/url-join": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.3.tgz",
-      "integrity": "sha1-E19AoBFA7TO1IoNume0g38EFYTc="
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-0.8.6.tgz",
+      "integrity": "sha512-7ynfYbbQHV3iz7K77wzgVoBBisyoMuFhLSoIhs1dl49WPzMZ0ybVqUq6Opa6n+0vBaWDXmzNbBkeNzsmPFWDJA=="
+    },
+    "@unimodules/core": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@unimodules/core/-/core-7.1.2.tgz",
+      "integrity": "sha512-lY+e2TAFuebD3vshHMIRqru3X4+k7Xkba4Wa7QsDBd+ex4c4N2dHAO61E2SrGD9+TRBD8w/o7mzK6ljbqRnbyg==",
+      "optional": true,
+      "requires": {
+        "compare-versions": "^3.4.0"
+      }
+    },
+    "@unimodules/react-native-adapter": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@unimodules/react-native-adapter/-/react-native-adapter-6.3.9.tgz",
+      "integrity": "sha512-i9/9Si4AQ8awls+YGAKkByFbeAsOPgUNeLoYeh2SQ3ddjxJ5ZJDtq/I74clDnpDcn8zS9pYlcDJ9fgVJa39Glw==",
+      "optional": true,
+      "requires": {
+        "expo-modules-autolinking": "^0.0.3",
+        "invariant": "^2.2.4"
+      }
     },
     "@webex/common": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.80.178.tgz",
-      "integrity": "sha512-UMZSSUxomcvnFvOt3/IiNMBDLGeLMPR62u/9ZJ6R0qUPsIIJpO9yBI+6N04fJS4hvTBinDMeD66ql42hATRmiQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.161.0.tgz",
+      "integrity": "sha512-gY0IK2yeNv10b6AYrXa5FAicDvYd91jkY4Mf/L1UosuOLHA8UEVRNIQxMDPSdoaHUXBk+WI6rti1d/XnQFz8QQ==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
         "backoff": "^2.5.0",
+        "bowser": "^2.11.0",
         "core-decorators": "^0.20.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "safe-buffer": "^5.2.0",
         "urlsafe-base64": "^1.0.0"
       },
       "dependencies": {
-        "backoff": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-          "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-          "requires": {
-            "precond": "0.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "precond": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-          "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "@webex/common-timers": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.80.178.tgz",
-      "integrity": "sha512-BJUWfDtqareL6HJbLjTk2dmiuGqwtDGHQF50YFKkz6ck2ZapmJZSsox3q3tsImLavYfrF0ltQYnRCLOx0q4mww==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.161.0.tgz",
+      "integrity": "sha512-30oeHYvnhfP79KRw5+tDbzOkqXslPy4xjcQMYDWTsg/xvUeSaX9Wf7Odumnkspee4SNuqcqYTCKP7Pc8ZCSVHg==",
       "requires": {
+        "@babel/runtime-corejs2": "^7.14.8",
         "envify": "^4.1.0"
       }
     },
     "@webex/helper-html": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.80.178.tgz",
-      "integrity": "sha512-08pTVqvvNvXRsqvtSHz34At8Y6eMBGs5P1byvYdl6CE80LIfng69+cNFPzQTLKvRFmP+o3GZc9Uj8Yc1GINaWQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.161.0.tgz",
+      "integrity": "sha512-kQ7UX2X4Oo5R3W42ATIHr/Mb/VpJO+FNRtHQaPFs5vmLUT4Zy4hJ7AHn1Mo7FkOIn40eAe5ezSs/x+ifsal/aw==",
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/helper-image": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.80.178.tgz",
-      "integrity": "sha512-LwnqJCP7/yank0dVM5qiq9K1ALFPgHl68Z9AfObNSorNC8PljdcG/hsowNkM9rj/s0rv9+eB53hbL0g68FIzJA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.161.0.tgz",
+      "integrity": "sha512-KdkVqS7D0hoDKCTFDcVMmDy7UhAEynitTkXlwHYJFigiq5Lq0R/YHdk7DiziHMABMxfrq6vl9mhUakzXjhQCAg==",
       "requires": {
-        "@webex/http-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/http-core": "1.161.0",
         "envify": "^4.1.0",
-        "exif": "^0.6.0",
+        "exifr": "^5.0.3",
         "gm": "^1.23.1",
-        "lodash": "^4.17.15",
-        "mime-types": "^2.1.24"
+        "lodash": "^4.17.21",
+        "mime": "^2.4.4",
+        "safe-buffer": "^5.2.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
         },
-        "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
-        },
-        "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-          "requires": {
-            "mime-db": "1.43.0"
-          }
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "@webex/http-core": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.80.178.tgz",
-      "integrity": "sha512-iBaHvEaX9KdMaB4mUM+dpyM56qWOplI4GFDVAxYmf8SLZMiiQwjCC6gu/TLMTBcg4vPiQwO/9tHVPCkk//vNFA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.161.0.tgz",
+      "integrity": "sha512-2JCvZ1lJwwv2Ajn9cn7QrbD6QbMR1p9pXu2JcjhYP2WdHssT6pBvNMZ009uJ1JRGexY3QQKuBNlzn8M87xbQtw==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
         "envify": "^4.1.0",
-        "file-type": "^3.9.0",
+        "file-type": "^16.0.1",
         "global": "^4.4.0",
         "is-function": "^1.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "parse-headers": "^2.0.2",
         "qs": "^6.7.0",
         "request": "^2.88.0",
+        "safe-buffer": "^5.2.0",
         "xtend": "^4.0.2"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -329,206 +430,46 @@
             "uri-js": "^4.2.2"
           }
         },
-        "asn1": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
         "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "extend": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-        },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
           }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha512-4Dj8Rf+fQ+/Pn7C5qeEX02op1WfOss3PKTE9Nsop3Dx+6UPxlm1dr/og7o2cRa5hNN07CACr4NFzRLtj/rjWog==",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
           "requires": {
-            "mime-db": "1.43.0"
+            "mime-db": "1.52.0"
           }
         },
         "oauth-sign": {
@@ -536,20 +477,10 @@
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
-        "psl": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-          "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-        },
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "qs": {
           "version": "6.11.2",
@@ -587,9 +518,9 @@
           },
           "dependencies": {
             "qs": {
-              "version": "6.5.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+              "version": "6.5.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+              "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
             }
           }
         },
@@ -597,27 +528,6 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "sshpk": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-          "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
         },
         "tough-cookie": {
           "version": "2.5.0",
@@ -628,41 +538,10 @@
             "punycode": "^2.1.1"
           }
         },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
-        "uri-js": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-          "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
-          }
         },
         "xtend": {
           "version": "4.0.2",
@@ -672,51 +551,39 @@
       }
     },
     "@webex/internal-plugin-calendar": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.80.178.tgz",
-      "integrity": "sha512-kl4MUC5crbKPEAbQKa6ELc/26CkQXQMBOlHcUKgvBNXkUl7YlM6ezWfBRnZr1AAYNGMW9Ezzd+TvL1iojg5n2Q==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.161.0.tgz",
+      "integrity": "sha512-tbw50C4rW6MAWpu8rD1wQyivmDjR6lA6dSYwddy2jNNvmmq0lOkR0CQjry2KTxbzpFQzptXEMmpXbMZFCRCLKw==",
       "requires": {
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-encryption": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-encryption": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "btoa": "^1.2.1",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/internal-plugin-conversation": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.80.178.tgz",
-      "integrity": "sha512-yB+3KCHMAi0YN/sDbaN0NeC/NzNe8Em5AaLID+9CqGE5G/94QTW4O2YssyqJJ2CvDhLlhXS5B0HsqbJGAKgQMA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.161.0.tgz",
+      "integrity": "sha512-1/yud5FtF7QXHJn+NspdDaBF5ecQmnoafX+8LiZhnOSO8/eCuWPkBqzxTc7hvnI0+oluontZHKR2ZN6wrREn1Q==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/helper-html": "1.80.178",
-        "@webex/helper-image": "1.80.178",
-        "@webex/internal-plugin-encryption": "1.80.178",
-        "@webex/internal-plugin-user": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
-        "crypto-js": "^3.1.9-1",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/helper-html": "1.161.0",
+        "@webex/helper-image": "1.161.0",
+        "@webex/internal-plugin-encryption": "1.161.0",
+        "@webex/internal-plugin-user": "1.161.0",
+        "@webex/webex-core": "1.161.0",
+        "crypto-js": "^4.1.1",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
-        "node-scr": "^0.2.2",
+        "lodash": "^4.17.21",
+        "node-scr": "^0.3.0",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -725,49 +592,44 @@
       }
     },
     "@webex/internal-plugin-device": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-1.80.178.tgz",
-      "integrity": "sha512-1QJ+cy2OKOzKpFMEj0Qq51/e2vWFhpoqxpcClGZ+D3tt5H/xHa1GHtgdWXSalfF/PKJl6TSnR0sgD/p3MoQcBQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-1.161.0.tgz",
+      "integrity": "sha512-y8MV6gmHdC/5WijCPrTXNmQGRSqt4WADNT4CzdyYBtAkybOHRJRineE2IqhH72MRYkh/+aDBjW2mvbGhMUkwWg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/http-core": "1.80.178",
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/http-core": "1.161.0",
+        "@webex/internal-plugin-metrics": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "ampersand-collection": "^2.0.2",
         "ampersand-state": "^5.0.3",
-        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/internal-plugin-encryption": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.80.178.tgz",
-      "integrity": "sha512-R2AJh/cA/g3vIgYmbkqOxE/Z/Trj1cl640Ldshj7wwT7cX/KTmLD3dChP4uyV0X316v5EofZRwLyMSi4qX/Ysw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.161.0.tgz",
+      "integrity": "sha512-Fgq4UyHLmKhfwWQBBLhK+Krz0UIB/cu3nwPnNr2EvUb7ZeoxPcd+jnMEHp+QDEUMa41Vr59pYPPBxvhtv1CLqg==",
       "requires": {
-        "@peculiar/webcrypto": "^1.0.22",
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/http-core": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/http-core": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "asn1js": "^2.0.26",
-        "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
-        "node-jose": "^0.11.1",
-        "node-kms": "^0.3.2",
-        "node-scr": "^0.2.2",
+        "isomorphic-webcrypto": "^2.3.8",
+        "lodash": "^4.17.21",
+        "node-jose": "^2.0.0",
+        "node-kms": "^0.4.0",
+        "node-scr": "^0.3.0",
         "pkijs": "^2.1.84",
+        "safe-buffer": "^5.2.0",
         "valid-url": "^1.0.9"
       },
       "dependencies": {
@@ -779,202 +641,162 @@
             "ms": "^2.1.1"
           }
         },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "@webex/internal-plugin-feature": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.80.178.tgz",
-      "integrity": "sha512-2UJgZu8F5x0MaLSS5StOLOIEpirYy80uqCRxyTvuqk/6/bJe9dw01kCXZtVT1xC0bya4Z2bjzhzqGkcDaOMF+A==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.161.0.tgz",
+      "integrity": "sha512-sKuICbBHWx7Fi60EsdLe0H4preh8XT+I464TJ01bE2EDEldEbl1viFrAE1TOAlkXokWb2+xKEH4c/9hFQqB4VA==",
       "requires": {
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/internal-plugin-lyra": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.80.178.tgz",
-      "integrity": "sha512-023/09xkyc6O8PV3L49dWnxt5HDO5yW4RFhc5zpNwZI6MG+Jpuj9PXgJ6uZ4NJbIMD4T59zcNioPE5f9lj82/A==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.161.0.tgz",
+      "integrity": "sha512-B50bsDVdvJBNP56j0RbLxlbByIr/CRpRzBTKfGzV6zQoXUYs99inLTCkMc3Q4NwRCISaeBzcO5wFadJG8H62Xg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-encryption": "1.80.178",
-        "@webex/internal-plugin-feature": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-encryption": "1.161.0",
+        "@webex/internal-plugin-feature": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-mercury": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.80.178.tgz",
-      "integrity": "sha512-oKlOIwqTMkkC4C9q6fQ1XTSbL0a0IvO0lrMvr/jF4gLWrg5EszXjuvft+qWB4N5z3hmHGvubrQyUNuqvBhWvaw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.161.0.tgz",
+      "integrity": "sha512-wm9STxbSDNj/1iW198LWk7F5M5AgUI1+yonSSUDOvc8QmxRuk7fuk1fZ0VrqNAR7uEkO56gEmnG+91pJTt71eA==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-feature": "1.80.178",
-        "@webex/internal-plugin-metrics": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-feature": "1.161.0",
+        "@webex/internal-plugin-metrics": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "backoff": "^2.5.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "uuid": "^3.3.2",
-        "ws": "^4.1.0"
+        "ws": "^8.2.2"
       },
       "dependencies": {
-        "async-limiter": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-          "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-        },
-        "backoff": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
-          "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
-          "requires": {
-            "precond": "0.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "precond": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-          "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "ws": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0"
-          }
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
         }
       }
     },
     "@webex/internal-plugin-metrics": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.80.178.tgz",
-      "integrity": "sha512-gibR0AT/yvmWufCyBZA74THzDez80WTbO28jW+JKidlpcjf6+Gx6SrgQ+nl60I3zHf7v9TVOsHWMsytRQRWNmQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.161.0.tgz",
+      "integrity": "sha512-B/OJhvZlUNBRhPck1IIxJRAg7eTTtry6+/K+wmjLwtfH1FF9HgSOFu0i7cQiyfql/rzLrs4QaG/6PpqiGl+cuQ==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-presence": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.80.178.tgz",
-      "integrity": "sha512-/nJ72ttqLkdBOv8Z7wN1yWIPLyaPtJu3GDoshHwXEtvF51WzR5CHt51VhgmOu0g6spejBcYMJ5eNppozrnQqCQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.161.0.tgz",
+      "integrity": "sha512-ch8ojz267xyNlOjywHRTg0rKbBGyNZ4CkSTq1N0TaJ2ne0ZM9mZA+mTC2cQ/p4Fi3jQA3iE5FOQZERvxsY5ABw==",
       "requires": {
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/internal-plugin-search": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.80.178.tgz",
-      "integrity": "sha512-zWojY1Iz2tF3yN9py5tg5d9dkyV8MetMMB01Mp5sCLGjInCEBhwbSMcHTOu2tigzr8pd61Y5EP5pvD7VOWP5Kg==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.161.0.tgz",
+      "integrity": "sha512-9wWIPVNrvsOQ8WOjFsOqzT4s5PDvmJz+L+ZKREsyqLsH7RfO92dsjUnIKYhpYQj7TGaByVlmdOzLf//IjJ4N7Q==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-encryption": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-encryption": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
+      }
+    },
+    "@webex/internal-plugin-support": {
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-support/-/internal-plugin-support-1.161.0.tgz",
+      "integrity": "sha512-ye7XQHXApxGnnbMkPRbN1QA2fFFIISvccsn20PJszdVX4GRohGSBhjQxfZlZSK2MaCrGsFR3FhB4/kspURXw6g==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.21",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
     "@webex/internal-plugin-user": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.80.178.tgz",
-      "integrity": "sha512-KXKvxi34IsRXTBj6KTboSVVhLVe6yb43Ht2HPrGp1Yu8Qx8eptnBbKGEZpAJX1KoQEreQxbRnl6t8GnwRdo3Jw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.161.0.tgz",
+      "integrity": "sha512-4NHMIi1+0trR5TjhduX5QTQ+8acNhlSJ64XE4nwxRIer0hADAlQXBLPA1IFf72PYG8l2WijQ0vy8tv07Wra50A==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/plugin-attachment-actions": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.80.178.tgz",
-      "integrity": "sha512-jW/bq/TRbYaTQrZJdri1CWxIk+CCBgtsdj8Uf2utuBz9aT6jEto2jTZOo7w0G8IeIjCqk+yGoVWBGcCBHuc7Xw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.161.0.tgz",
+      "integrity": "sha512-TBtdHUrkv2i6+ABrLvKZv9VLDEGb/LoJ04xTygMMqKgTrRrsmoS62bj1a2AFYaxKbpQdGPTsuV7/6H4wB5Ikzg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -984,11 +806,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.3",
@@ -998,34 +815,30 @@
       }
     },
     "@webex/plugin-authorization": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.80.178.tgz",
-      "integrity": "sha512-iVSAlJinBVGA48ZUKJW5lG0NSFgvfZwavFe4mD+BKF05NdvTlp9aXRe90evkOWT3VV97rc4PNqd8iqJelaWCPg==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.161.0.tgz",
+      "integrity": "sha512-0ZQfYd7Pdr846Guh1BYcSQJtS0woUQVvNebRXGhwr+YZPC4oYLMk5ISrY+1oocXrZbdJdfkka4ij53lhazYA/Q==",
       "requires": {
-        "@webex/plugin-authorization-browser": "1.80.178",
-        "@webex/plugin-authorization-node": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/plugin-authorization-browser": "1.161.0",
+        "@webex/plugin-authorization-node": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-authorization-browser": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.80.178.tgz",
-      "integrity": "sha512-Z9J+MAQ+29eGEINL1hZv4PwxkyxW3AccAsHxvCmO/h8y/3Cu0x8jQ3xIos7vmmLU5dtqIv0XDktnDmd30/xeNw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.161.0.tgz",
+      "integrity": "sha512-MSipQ/IQ8fWTu3sDWmQoxN0yGXBwwG3cPt9M+tE4QMmzkF+PjBSGTCmIzLy147U24h5d9wQGGJBWSn8tQwbM1Q==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -1034,37 +847,32 @@
       }
     },
     "@webex/plugin-authorization-node": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.80.178.tgz",
-      "integrity": "sha512-8mAsOKfiPfYSXiAIroxE/GspZMtw0jcm6Rk+ENJhWrXSgQf5XgPrRR/y3uIpZ7PNeboUNObRKkx5vjkwHgbMBQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.161.0.tgz",
+      "integrity": "sha512-oYYHjEv/cVt+ZAbos1En4zA7+GtsxabwR0ZnjaHctSSxfpHoemzO68LJXvqJQRIbVl9do6GNizic4PN5KabhfQ==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-device-manager": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.80.178.tgz",
-      "integrity": "sha512-AiXCrLl7r2EsJ+SrZYpJKU4MDECVQoSCHR8nJ8V5yGtklKntiHFpj5P6BFOhI6+l6kU3zaCEOhbtQJ0QS37KaA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.161.0.tgz",
+      "integrity": "sha512-xzIHP0llGJojMeuoMEtgnDPYpbj/HDMprGVMV/AGyCAuOEdY6mORNgbdavXX/YFVPJL6awBb7G6NXd77Aowujg==",
       "requires": {
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-lyra": "1.80.178",
-        "@webex/internal-plugin-search": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-lyra": "1.161.0",
+        "@webex/internal-plugin-search": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -1073,48 +881,63 @@
       }
     },
     "@webex/plugin-logger": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.80.178.tgz",
-      "integrity": "sha512-maEaqtjemF+G5fI3/+E4YkpBqPhXIdGXRE4kXaqj1uRG4wiksopYOAroQ0ILtsAo3yOvqXu6KIiwnRZ37Da8cA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.161.0.tgz",
+      "integrity": "sha512-+JHz2Qgm7pHq2Syfv457N0rQPiSivVFqiq3V+KQ1iAUJiDbz3DlUTIGR90njtrcGDdNwHqqwbZonJ6KZUcOotQ==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/plugin-meetings": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.80.178.tgz",
-      "integrity": "sha512-aYKtPkMNPqRDuViCsMtLo3mnoZGxvQiogF1ctB6cckatihQnta/Du8xkcr0fLMyBhwhFcX2F7mx0zCWnUZNpFg==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.161.0.tgz",
+      "integrity": "sha512-nAYh5ZWX+vGDoxLvUHL8/YdT29VsbHZGw/U2q216KDuvxwhDNWGOnHFp32Eudi1cX79phZSOPgjzwtJ4Xq9oYg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
-        "bowser": "1.9.4",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
+        "bowser": "^2.11.0",
         "btoa": "^1.2.1",
         "envify": "^4.1.0",
         "global": "^4.4.0",
+        "ip-anonymize": "^0.1.0",
         "javascript-state-machine": "^3.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
+        "readable-stream": "^3.6.0",
         "sdp-transform": "^2.12.0",
-        "uuid": "^3.3.2"
+        "uuid": "^3.3.2",
+        "webrtc-adapter": "^7.7.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
         },
         "uuid": {
           "version": "3.4.0",
@@ -1124,18 +947,18 @@
       }
     },
     "@webex/plugin-memberships": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.80.178.tgz",
-      "integrity": "sha512-10YCfIuyj89GkBm2EClOafmedQVk9OkDNP5JLnaSDhgzbj/32geFkTApXMrKKaVr7EQLofpvZNtIPKFY+cuCfw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.161.0.tgz",
+      "integrity": "sha512-pjs7QAKu8E8QN3niULoZqQXkjfrD+Hqxe3S68ZstBPFvLIhmngP6SRPVQ0bKQIY1V25jGQ1fLigfjOnYjgBgMg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -1145,11 +968,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.3",
@@ -1159,64 +977,43 @@
       }
     },
     "@webex/plugin-messages": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.80.178.tgz",
-      "integrity": "sha512-OUOwR4u51p+Y2sGdIHLSIS33tNJFcUbkZJhT6Rnlu6xevJjwRALcUYJpVvkALNpiLos/j3OOfEc5hk7xCOJoOA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.161.0.tgz",
+      "integrity": "sha512-vDTdYK0zulpK9J1+ucK3ZB+hGCA3lo0hKIscR0ScN33ideaiEDEFFBRqckmdeRammnyHHZ8Avi/kVYxfBbhtZg==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
-        "debug": "^3.2.6",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
+        "lodash": "^4.17.21"
       }
     },
     "@webex/plugin-people": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.80.178.tgz",
-      "integrity": "sha512-bOaxiawzoPUdCrvFaxI9X+NlakOeXR2wv7rereBO2+QGU4tt7TheURhHGWCDggtcwYIqGJv2XipNdJhI4w0dTA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.161.0.tgz",
+      "integrity": "sha512-G6LbPPqgTht0pkorIJLpkChEnAo+R7u9q51KoPOLj1kM9LOqzOT6JA55z/WfzBZRwYITbfL7qV58FhyQ15sOgA==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-rooms": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.80.178.tgz",
-      "integrity": "sha512-ttBOJcil8zJwisK+vAHupFDAtbDT/7BeLIDTaV3YVXn/iHk8jKTPyxu2HDCXlhQvApV8F9sBDrOxigEthqBCEw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.161.0.tgz",
+      "integrity": "sha512-9amxryhzajJyyDFpLGa+YCBI4yvPoTgIj30dQZO0TniCbOYw/QM3BRzvtcn8+195V/ePQeR0RYcd9vqwtWy2iw==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/internal-plugin-conversation": "1.80.178",
-        "@webex/internal-plugin-mercury": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/internal-plugin-conversation": "1.161.0",
+        "@webex/internal-plugin-mercury": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -1226,11 +1023,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.3",
@@ -1240,68 +1032,66 @@
       }
     },
     "@webex/plugin-team-memberships": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.80.178.tgz",
-      "integrity": "sha512-GsQutBpXmLd4yNdnqJPQYTtmoQaumVhdtk3QJ5P0XHH0NWOATvfr9DFg5H3zDsAGW15Bc3TJ8qXDQ7VaYJ1lLw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.161.0.tgz",
+      "integrity": "sha512-LIrp/hpd4RSl0gh97xl7xtopz0PSbeoUatO8u4XkBjUAZ6iPjYAyRuu68yXG7QxfCacePF+jdrdnOuhWsBMIVw==",
       "requires": {
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-teams": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.80.178.tgz",
-      "integrity": "sha512-Lo32lfa0549TkFeLXlfEDNd4N9k7DspxwEMpQUJzcKgmmuMI9uIQMlRt3uI2fAkQHL+D2AtK2pxsbY2iH2yzWQ==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.161.0.tgz",
+      "integrity": "sha512-IrZf33pY6FTStoBumxTSAAXSmzQ7Izia6ICPBi79J2MWrt81lm4MQP5OP+eg2Ub2U6kwrflIfTfYPNjG+OVJNQ==",
       "requires": {
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-webhooks": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.80.178.tgz",
-      "integrity": "sha512-2yPnjMOLHZRUWjxS8uRZQR8Yh8sjqqF+tb/XmXTYwqd7RtLvuGOB1AmWzyUuv0IM2HGQBnViJB4sF84zLZKvZA==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.161.0.tgz",
+      "integrity": "sha512-KA3rUC9ukfxyEiXwJdeZDxk+HDRtwkn5aE5ZAole7HxhidcY7Obvi+NJuSVSvp+W6giC0McFivoLP6UMwnPEww==",
       "requires": {
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/storage-adapter-local-storage": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.80.178.tgz",
-      "integrity": "sha512-wLrhqchxXSL7O0iq8x7HA51H2RCHlRnPptpj+OV0DZt0mrx7phSO2FT2fY7ySyjUkN+QescJAb9QU37pFbn8ug==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.161.0.tgz",
+      "integrity": "sha512-Dzh/PQUbGeQ4h7Aq67QlS0uPZM/zldu8GZo8xjpZSGWDQx+t4ygcSXNgbVXLl9FrItZsxNAxBG2WTkNA5dBzIQ==",
       "requires": {
-        "@webex/webex-core": "1.80.178",
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/webex-core": "1.161.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/webex-core": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.80.178.tgz",
-      "integrity": "sha512-K8wVB4DCbbCfMz2mH5LG9farSS1LU8dV9vFyoGBSHt/N/Ori502QFmP+dA0lVg1zay3eQt/GHO3XNCI+Q+lnkw==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.161.0.tgz",
+      "integrity": "sha512-vmHdkZMXE+iUso1knXYnREOvm6NyUwLnSao+47xcqIvTKh+zOxl0VbvP+ovVLYux9xnqIyr6IQERDhJjKgml8w==",
       "requires": {
-        "@webex/common": "1.80.178",
-        "@webex/common-timers": "1.80.178",
-        "@webex/http-core": "1.80.178",
-        "@webex/webex-core": "1.80.178",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/common": "1.161.0",
+        "@webex/common-timers": "1.161.0",
+        "@webex/http-core": "1.161.0",
+        "@webex/webex-core": "1.161.0",
         "ampersand-collection": "^2.0.2",
         "ampersand-events": "^2.0.2",
         "ampersand-state": "^5.0.3",
-        "babel-runtime": "^6.26.0",
         "core-decorators": "^0.20.0",
-        "crypto-js": "^3.1.9-1",
+        "crypto-js": "^4.1.1",
         "envify": "^4.1.0",
         "jsonwebtoken": "^8.5.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -1312,7 +1102,7 @@
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+      "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q=="
     },
     "accepts": {
       "version": "1.3.8",
@@ -1339,9 +1129,9 @@
       }
     },
     "adaptivecards": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.5.tgz",
-      "integrity": "sha512-Rj+QK0qtBOfLGy3ClXylKxL4ze/a6mtPiJL7Ctjyc1Uso9O1x/LAAu49F36ZQbgAa8vWkKW91RKcwBBOxk3HDg=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.6.tgz",
+      "integrity": "sha512-/l34rvdRzQ20QdGLk+awRUotexu3N4Ih3O0qR8cM+2wWe0pggvWhmFdwVFmM+YgIS5pWtl2u7XAJynUaFIQAIw=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -1365,13 +1155,13 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "optional": true
     },
     "ampersand-class-extend": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-2.0.0.tgz",
-      "integrity": "sha1-Uolf+lkhdjSmGI/RhLEEj12Aiv8=",
+      "integrity": "sha512-i8hQvA4vZz9UfQAi0A4oBASYOZzlYgjFVkw0K1xpeKNSvq+KYkFOqJKkNvHCbbuKUNJnFk3kECSKPDAJ6ocEOg==",
       "requires": {
         "lodash": "^4.11.1"
       }
@@ -1390,7 +1180,7 @@
     "ampersand-events": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
-      "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
+      "integrity": "sha512-pPnVEJviRxXi9YhZA9j3GwGGBTlDLi+YIoBvrpKXgce+CO1nMlZU2aOV8OJogNuR2YPbptAUHNz7SKX+MvLj8A==",
       "requires": {
         "ampersand-version": "^1.0.2",
         "lodash": "^4.6.1"
@@ -1411,7 +1201,7 @@
     "ampersand-version": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ampersand-version/-/ampersand-version-1.0.2.tgz",
-      "integrity": "sha1-/489TOrE0yzNg/a9Zpc5f3tZ4sA=",
+      "integrity": "sha512-FVVLY7Pghtgc8pQl0rF3A3+OS/CZ+/ILLMIYIaO1cA9v5SRkainqUMfSot3fu32svuThIsYK3q9iCsH9W5+mWQ==",
       "requires": {
         "find-root": "^0.1.1",
         "through2": "^0.6.3"
@@ -1430,9 +1220,16 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+        }
       }
     },
     "array-flatten": {
@@ -1443,22 +1240,27 @@
     "array-next": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-next/-/array-next-0.0.1.tgz",
-      "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
+      "integrity": "sha512-sBOC/Iaz2hCcYi2XlyRfyZCRUxamlE5NJXEFjE9BTx23HALnWAFsPjGtfrAclt9o3G/38Het2yyeyOd3CEY7lg=="
     },
     "array-parallel": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
-      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
+      "integrity": "sha512-TDPTwSWW5E4oiFiKmz6RGJ/a80Y91GuLgUYuLd49+XBS75tYo8PNgaT2K/OxuQYqkoI852MDGBorg9OcUSTQ8w=="
     },
     "array-series": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
-      "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8="
+      "integrity": "sha512-L0XlBwfx9QetHOsbLDrE/vh2t018w9462HM3iaFfxRiK83aJjAt/Ja3NMkOW7FICwWTlQBa3ZbL5FKhuQWkDrg=="
     },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "asmcrypto.js": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-0.22.0.tgz",
+      "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
     },
     "asn1": {
       "version": "0.2.3",
@@ -1466,15 +1268,11 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1js": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
-      "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
-      "dependencies": {
-        "pvutils": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-          "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
-        }
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
+      "integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
+      "requires": {
+        "pvutils": "^1.1.3"
       }
     },
     "assert-plus": {
@@ -1501,6 +1299,12 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "optional": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1519,51 +1323,49 @@
         "follow-redirects": "^1.14.0"
       }
     },
-    "b64u": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/b64u/-/b64u-2.0.0.tgz",
-      "integrity": "sha512-N3SnhKhQtwm9a4+rdNT0JvnNdPlRwpQZN4tfJwOE3/qJVzM+OlYj/Iz2n1S3KXAQmKHaRwWUNW5gEnjuD8cXHg=="
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+    "b64-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
+      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
+        "base-64": "^0.1.0"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+    "b64u-lite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/b64u-lite/-/b64u-lite-1.1.0.tgz",
+      "integrity": "sha512-929qWGDVCRph7gQVTC6koHqQIpF4vtVaSbwLltFQo44B1bYUquALswZdBKFfrJCPEnsCOvWkJsPdQYZ/Ukhw8A==",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "b64-lite": "^1.4.0"
       }
     },
     "backoff": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
-      "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
+      "requires": {
+        "precond": "0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha1-Y5nVcuK8P5CpqLItXbsKMtM/eI0="
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -1678,11 +1480,12 @@
       }
     },
     "botbuilder": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.16.0.tgz",
-      "integrity": "sha1-cA6jkYksYm+h+SJojSx0KwaE9QM=",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.30.0.tgz",
+      "integrity": "sha512-TpqYa75IvU+aa4VXS0ZL0LFGGjDnw/O04XnAc1VzQw+S82s0vA7YHLAKW9LaKkz4f3cdQKskU48+tZsx+D3wzg==",
       "requires": {
         "@types/async": "^2.0.48",
+        "@types/clone-deep": "^4.0.1",
         "@types/express": "^4.11.1",
         "@types/form-data": "^2.2.1",
         "@types/jsonwebtoken": "^7.2.6",
@@ -1693,6 +1496,7 @@
         "async": "^1.5.2",
         "base64url": "^3.0.0",
         "chrono-node": "^1.1.3",
+        "clone-deep": "^4.0.1",
         "jsonwebtoken": "^8.2.2",
         "promise": "^7.1.1",
         "request": "^2.88.0",
@@ -1702,128 +1506,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "aws4": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-          "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
-          "requires": {
-            "ajv": "^6.5.5",
-            "har-schema": "^2.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
-        },
-        "mime-db": {
-          "version": "1.38.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-          "integrity": "sha1-GiqrFtqesWe0nG5N8tnGjWPY4q0="
-        },
-        "mime-types": {
-          "version": "2.1.22",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-          "integrity": "sha1-/ms1WhkJJqt2mMmgVWoRGZshmb0=",
-          "requires": {
-            "mime-db": "~1.38.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        },
-        "url-join": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
-        }
-      }
-    },
-    "botbuilder-teams": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/botbuilder-teams/-/botbuilder-teams-0.2.9.tgz",
-      "integrity": "sha512-aLb3pdGAZaBPBZaVcjxSnzuQPIiL4AIFIxmLl4pJBdve+FXZesS7ZOCMrotsAea9bj0HoYffqpYaFAT4UHQbuA==",
-      "requires": {
-        "adaptivecards": "^1.0.0",
-        "botbuilder": "^3.30.0",
-        "crypto": "^1.0.1",
-        "ms-rest": "^2.5.0",
-        "sprintf-js": "^1.1.1",
-        "tsc": "^1.20150623.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1832,210 +1517,9 @@
           }
         },
         "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-        },
-        "botbuilder": {
-          "version": "3.30.0",
-          "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-3.30.0.tgz",
-          "integrity": "sha512-TpqYa75IvU+aa4VXS0ZL0LFGGjDnw/O04XnAc1VzQw+S82s0vA7YHLAKW9LaKkz4f3cdQKskU48+tZsx+D3wzg==",
-          "requires": {
-            "@types/async": "^2.0.48",
-            "@types/clone-deep": "^4.0.1",
-            "@types/express": "^4.11.1",
-            "@types/form-data": "^2.2.1",
-            "@types/jsonwebtoken": "^7.2.6",
-            "@types/node": "^9.6.1",
-            "@types/request": "^2.47.0",
-            "@types/sprintf-js": "^1.1.0",
-            "@types/url-join": "^0.8.1",
-            "async": "^1.5.2",
-            "base64url": "^3.0.0",
-            "chrono-node": "^1.1.3",
-            "clone-deep": "^4.0.1",
-            "jsonwebtoken": "^8.2.2",
-            "promise": "^7.1.1",
-            "request": "^2.88.0",
-            "rsa-pem-from-mod-exp": "^0.8.4",
-            "sprintf-js": "^1.0.3",
-            "url-join": "^1.1.0"
-          },
-          "dependencies": {
-            "@types/node-fetch": {
-              "version": "2.5.10",
-              "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
-              "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
-              "requires": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-              },
-              "dependencies": {
-                "@types/node": {
-                  "version": "15.12.0",
-                  "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.0.tgz",
-                  "integrity": "sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw=="
-                }
-              }
-            },
-            "adal-node": {
-              "version": "0.2.2",
-              "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.2.tgz",
-              "integrity": "sha512-luzQ9cXOjUlZoCiWeYbyR+nHwScSrPTDTbOInFphQs/PnwNz6wAIVkbsHEXtvYBnjLctByTTI8ccfpGX100oRQ==",
-              "requires": {
-                "@types/node": "^8.0.47",
-                "async": "^2.6.3",
-                "axios": "^0.21.1",
-                "date-utils": "*",
-                "jws": "3.x.x",
-                "underscore": ">= 1.3.1",
-                "uuid": "^3.1.0",
-                "xmldom": ">= 0.1.x",
-                "xpath.js": "~1.1.0"
-              },
-              "dependencies": {
-                "@types/node": {
-                  "version": "8.10.66",
-                  "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
-                  "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
-                },
-                "async": {
-                  "version": "2.6.3",
-                  "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-                  "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-                  "requires": {
-                    "lodash": "^4.17.14"
-                  }
-                }
-              }
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-            },
-            "axios": {
-              "version": "0.21.1",
-              "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-              "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-              "requires": {
-                "follow-redirects": "^1.10.0"
-              }
-            },
-            "buffer-equal-constant-time": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-              "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-            },
-            "combined-stream": {
-              "version": "1.0.8",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-              "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              }
-            },
-            "date-utils": {
-              "version": "1.2.21",
-              "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-              "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-            },
-            "ecdsa-sig-formatter": {
-              "version": "1.0.11",
-              "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-              "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "follow-redirects": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-              "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
-            },
-            "form-data": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-              "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "jwa": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-              "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-              "requires": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "jws": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-              "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-              "requires": {
-                "jwa": "^1.4.1",
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "lodash": {
-              "version": "4.17.21",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-            },
-            "mime-db": {
-              "version": "1.48.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-              "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
-            },
-            "mime-types": {
-              "version": "2.1.31",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-              "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-              "requires": {
-                "mime-db": "1.48.0"
-              }
-            },
-            "node-fetch": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-              "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-            },
-            "safe-buffer": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-            },
-            "underscore": {
-              "version": "1.13.1",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-              "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
-            },
-            "uuid": {
-              "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-            },
-            "xmldom": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-              "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
-            },
-            "xpath.js": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-              "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
-            }
-          }
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "extend": {
           "version": "3.0.2",
@@ -2043,16 +1527,16 @@
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
           }
         },
@@ -2062,16 +1546,16 @@
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
           "requires": {
-            "mime-db": "1.43.0"
+            "mime-db": "1.52.0"
           }
         },
         "oauth-sign": {
@@ -2080,9 +1564,9 @@
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "request": {
           "version": "2.88.2",
@@ -2111,11 +1595,6 @@
             "uuid": "^3.3.2"
           }
         },
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-        },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -2128,7 +1607,7 @@
         "url-join": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
+          "integrity": "sha512-zz1wZk4Lb5PTVwZ3HWDmm8XnlPvmOof6/fjdDPA5yBrUcbtV64U6bV832Zf1BtU2WkBBWaUT46wCs+l0HP5nhg=="
         },
         "uuid": {
           "version": "3.4.0",
@@ -2137,10 +1616,23 @@
         }
       }
     },
+    "botbuilder-teams": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/botbuilder-teams/-/botbuilder-teams-0.2.9.tgz",
+      "integrity": "sha512-aLb3pdGAZaBPBZaVcjxSnzuQPIiL4AIFIxmLl4pJBdve+FXZesS7ZOCMrotsAea9bj0HoYffqpYaFAT4UHQbuA==",
+      "requires": {
+        "adaptivecards": "^1.0.0",
+        "botbuilder": "^3.30.0",
+        "crypto": "^1.0.1",
+        "ms-rest": "^2.5.0",
+        "sprintf-js": "^1.1.1",
+        "tsc": "^1.20150623.0"
+      }
+    },
     "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2151,20 +1643,38 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "optional": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-request": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
+      "integrity": "sha512-YyNI4qJJ+piQG6MMEuo7J3Bzaqssufx04zpEKYfSrl/1Op59HWali9zMtBpXnkmqMcOuWJPZvudrm9wISmnCbg=="
     },
     "btoa": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
       "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -2175,6 +1685,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "bytestreamjs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-1.1.3.tgz",
+      "integrity": "sha512-JDGoiJ+yt+4Ui1e/vMWx5TRvmnErBBbsOkprXgbe1fRp2XZzI8MoknoiR/ZVCya9aWJbOhrJ5Heon1wrAdftkg=="
     },
     "call-bind": {
       "version": "1.0.5",
@@ -2210,17 +1725,22 @@
         }
       }
     },
+    "chardet": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.6.0.tgz",
+      "integrity": "sha512-+QOTw3otC4+FxdjK9RopGpNOglADbr4WPFi0SonkO99JbpkTPbMxmdm4NenhF5Zs+4gPXLI1+y2uazws5TMe8w=="
+    },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chrono-node": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.3.11.tgz",
-      "integrity": "sha1-uGomt+MVftzE/jN04bb5DK7cjjk=",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.4.8.tgz",
+      "integrity": "sha512-WwfW4/+i1e6tHx5opw/VCfxXnai12/tT5GK+wSHwKtdb0ZkAoxRGIfL8IzuFr/JEQTw4DxevysyX6+YbZSRKLQ==",
       "requires": {
-        "moment": "2.21.0"
+        "dayjs": "^1.8.19"
       }
     },
     "cli-table": {
@@ -2244,13 +1764,6 @@
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-        }
       }
     },
     "co": {
@@ -2281,10 +1794,20 @@
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
-    "coffeescript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
-      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "optional": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "optional": true
     },
     "colors": {
       "version": "1.0.3",
@@ -2303,6 +1826,12 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
+    },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2354,12 +1883,12 @@
     "core-decorators": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
-      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
+      "integrity": "sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA=="
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2369,7 +1898,7 @@
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
       "requires": {
         "lru-cache": "^4.0.1",
         "which": "^1.2.9"
@@ -2404,9 +1933,9 @@
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "crypto-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "ctype": {
       "version": "0.5.3",
@@ -2418,6 +1947,22 @@
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA=="
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      },
+      "dependencies": {
+        "type": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+        }
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2425,6 +1970,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "ddp.js": {
       "version": "0.5.0",
@@ -2440,9 +1990,9 @@
       }
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "define-data-property": {
       "version": "1.1.1",
@@ -2475,9 +2025,18 @@
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
+    "duration": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
+      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.46"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2491,7 +2050,7 @@
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2513,13 +2072,26 @@
       "requires": {
         "esprima": "^4.0.0",
         "through": "~2.3.4"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "requires": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-promise": {
@@ -2535,6 +2107,15 @@
         "es6-promise": "^4.0.3"
       }
     },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2548,34 +2129,50 @@
     "escodegen": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "integrity": "sha512-yhi5S+mNTOuRvyW4gWlg5W1byMaQGWWSYHXsuFZ7GBo7tpyOwi2EdzMP/QWxh9hwkD2m+wDVHJsxhRIj+v/b/A==",
       "requires": {
         "esprima": "^2.7.1",
         "estraverse": "^1.9.1",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.2.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A=="
+        }
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "estraverse": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+      "integrity": "sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA=="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -2590,12 +2187,58 @@
         "original": ">=0.0.5"
       }
     },
-    "exif": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/exif/-/exif-0.6.0.tgz",
-      "integrity": "sha1-YKYmaAdlQst+T1cZnUrG830sX0o=",
+    "exifr": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-5.0.6.tgz",
+      "integrity": "sha512-iDB4IhKoKVF+uDDrHRlyNxWqGaTxYluVWqvBWVG54HkQZe8qkFYl9eQrjEP3d8Q4UMBZ9rWu3Pa+mfC+o4CZuw=="
+    },
+    "expo-modules-autolinking": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-0.0.3.tgz",
+      "integrity": "sha512-azkCRYj/DxbK4udDuDxA9beYzQTwpJ5a9QA0bBgha2jHtWdFGF4ZZWSY+zNA5mtU3KqzYt8jWHfoqgSvKyu1Aw==",
+      "optional": true,
       "requires": {
-        "debug": "^2.2"
+        "chalk": "^4.1.0",
+        "commander": "^7.2.0",
+        "fast-glob": "^3.2.5",
+        "find-up": "~5.0.0",
+        "fs-extra": "^9.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "optional": true
+        }
+      }
+    },
+    "expo-random": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-13.4.0.tgz",
+      "integrity": "sha512-Z/Bbd+1MbkK8/4ukspgA3oMlcu0q3YTCu//7q2xHwy35huN6WCv4/Uw2OGyCiOQjAbU02zwq6swA+VgVmJRCEw==",
+      "optional": true,
+      "requires": {
+        "base64-js": "^1.3.0"
       }
     },
     "express": {
@@ -2704,6 +2347,14 @@
         "basic-auth": "^2.0.1"
       }
     },
+    "ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "requires": {
+        "type": "^2.7.2"
+      }
+    },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -2724,6 +2375,19 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
+    "fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "optional": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2732,7 +2396,16 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "optional": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "faye-websocket": {
       "version": "0.11.4",
@@ -2743,9 +2416,23 @@
       }
     },
     "file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "optional": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -2779,7 +2466,17 @@
     "find-root": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
-      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
+      "integrity": "sha512-GyDxVgA61TZcrgDJPqOqGBpi80Uf2yIstubgizi7AjC9yPdRrqBR+Y0MvK4kXnYlaoz3d+SGxDHMYVkwI/yd2w=="
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "optional": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
     },
     "flowdock": {
       "version": "0.9.1",
@@ -2992,6 +2689,18 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
+    "fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "optional": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs-jetpack": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-0.13.3.tgz",
@@ -3043,13 +2752,22 @@
     "glob": {
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
       "requires": {
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "2 || 3",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "optional": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "global": {
@@ -3062,9 +2780,9 @@
       }
     },
     "gm": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
-      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.25.0.tgz",
+      "integrity": "sha512-4kKdWXTtgQ4biIo7hZA396HT062nDVVHPjQcurNZ3o/voYN+o5FUC5kOwuORbpExp3XbTJ3SU7iRipiIhQtovw==",
       "requires": {
         "array-parallel": "~0.1.3",
         "array-series": "~0.1.5",
@@ -3095,25 +2813,24 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "optional": true
+    },
     "handlebars": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.14.tgz",
-      "integrity": "sha512-E7tDoyAA8ilZIV3xDJgl18sX3M8xB9/fMw8+mfW4msLW8jlX97bAnWgT3pmaNXuvzIEgSBMnAHfuXsB2hdzfow==",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "requires": {
-        "async": "^2.5.0",
-        "optimist": "^0.6.1",
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3144,9 +2861,10 @@
       }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "optional": true
     },
     "has-property-descriptors": {
       "version": "1.0.1",
@@ -3267,6 +2985,11 @@
           "version": "3.2.5",
           "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
           "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+        },
+        "coffeescript": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+          "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="
         }
       }
     },
@@ -3299,22 +3022,20 @@
       "integrity": "sha1-zqF+eCzndrdD9lOTk1s0MMLoGXw="
     },
     "hubot-irc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.0.tgz",
-      "integrity": "sha1-qV1cMshnAtljJOgnZWrUV65fT1o=",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/hubot-irc/-/hubot-irc-0.4.2.tgz",
+      "integrity": "sha512-Dj/v9WElKYEm/9iBpYf1yidGe5WPpe8Ir2tWccc3vGLv7B3DbJ5JJIqfBRpK4P6LbuBZfdirCBHS5ALaWNItmg==",
       "requires": {
-        "irc": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
+        "irc": "github:matrix-org/node-irc",
         "log": "1.4.0"
       }
     },
     "hubot-matteruser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.2.0.tgz",
-      "integrity": "sha1-YeDZDemcwS4QC5HpyTJGPSggZl0=",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/hubot-matteruser/-/hubot-matteruser-5.4.6.tgz",
+      "integrity": "sha512-G6zo19ODGrG2cz6458U+He3fdG1I/bSa0x+SI6HZjB429d5fKMkSkqGIdscLs5j1fs4nYH+9oGkhIrODMv5E7A==",
       "requires": {
-        "mattermost-client": "^6.1.0",
-        "parent-require": "^1.0.0",
-        "q": "^1.4.1"
+        "mattermost-client": "^6.5.0"
       }
     },
     "hubot-redis-brain": {
@@ -3413,7 +3134,7 @@
         "request": {
           "version": "2.9.3",
           "resolved": "https://registry.npmjs.org/request/-/request-2.9.3.tgz",
-          "integrity": "sha1-rArCYWlWiDfSiGqSsiwL0eFeetc="
+          "integrity": "sha512-SyyCqkxodKeOkoQqbLfLnwSGmVP/HXI3/CedADYEzH0Txml8P1p2XNyhfCJR9ejk8yqPMftdeYXH9+Oi0liX6Q=="
         }
       }
     },
@@ -3433,9 +3154,9 @@
       }
     },
     "hubot-xmpp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/hubot-xmpp/-/hubot-xmpp-0.2.5.tgz",
-      "integrity": "sha1-/8PfqqejTVSz2SPqcWcRLErcnB0=",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/hubot-xmpp/-/hubot-xmpp-0.2.6.tgz",
+      "integrity": "sha512-JqByL+unUz0WZYp0Miovr7iiHwkgISJLMiL9FBEdovYZwsSmZegixyqm0y5L7bIklz57J2oIs/jrY0DitKCt/A==",
       "requires": {
         "node-xmpp-client": "3.0.0",
         "uuid": "2.0.2"
@@ -3443,18 +3164,9 @@
       "dependencies": {
         "uuid": {
           "version": "2.0.2",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-          "integrity": "sha1-SL1WmPBnfjx5AaHEbvFbFkN5RyY="
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
+          "integrity": "sha512-BooSif/UQWXwaQme+4z32duvmtUUz/nlHsyGrrSCgsGf6snMrp9q/n1nGHwQzU12kaCeceODmAiRZA8TCK06jA=="
         }
-      }
-    },
-    "iconv": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.2.3.tgz",
-      "integrity": "sha1-4ITWDut9c9p/CpwJbkyKvgkL+u0=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.3.5"
       }
     },
     "iconv-lite": {
@@ -3465,10 +3177,15 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3479,34 +3196,69 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "optional": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "ip-anonymize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ip-anonymize/-/ip-anonymize-0.1.0.tgz",
+      "integrity": "sha512-cZJu+N5JKKFGMK0eEQWNaQMn2EhCysciVM6eotCJwfqotj16BTfVchKsJCH6mQAT9N0GC7oWRcsZ6Lb8dDiwTA=="
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "irc": {
-      "version": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
-      "from": "github:matrix-org/node-irc#e80eb07dfe2d1da55f3e0c4ac04dca4fbd2757fd",
+      "version": "github:matrix-org/node-irc#b684a46d11a9f0045f237d423bb83eb78b4eec39",
+      "from": "github:matrix-org/node-irc",
       "requires": {
-        "iconv": "~2.2.1",
-        "irc-colors": "^1.1.0",
-        "node-icu-charset-detector": "~0.2.0"
+        "chardet": "^1.5.1",
+        "iconv-lite": "^0.6.3",
+        "typed-emitter": "^2.1.0",
+        "utf-8-validate": "^6.0.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
-    },
-    "irc-colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/irc-colors/-/irc-colors-1.5.0.tgz",
-      "integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "optional": true
+    },
     "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "optional": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
@@ -3525,6 +3277,12 @@
         "xtend": "^4.0.0"
       }
     },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "optional": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3532,6 +3290,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w=="
     },
     "is-property": {
       "version": "1.0.2",
@@ -3541,7 +3304,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3556,12 +3319,30 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+    },
+    "isomorphic-webcrypto": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/isomorphic-webcrypto/-/isomorphic-webcrypto-2.3.8.tgz",
+      "integrity": "sha512-XddQSI0WYlSCjxtm1AI8kWQOulf7hAN3k3DclF1sxDJZqOe0pcsOt675zvWW91cZH9hYs3nlA3Ev8QK5i80SxQ==",
+      "requires": {
+        "@peculiar/webcrypto": "^1.0.22",
+        "@unimodules/core": "*",
+        "@unimodules/react-native-adapter": "*",
+        "asmcrypto.js": "^0.22.0",
+        "b64-lite": "^1.3.1",
+        "b64u-lite": "^1.0.1",
+        "expo-random": "*",
+        "msrcrypto": "^1.5.6",
+        "react-native-securerandom": "^0.1.1",
+        "str2buf": "^1.3.0",
+        "webcrypto-shim": "^0.1.4"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -3571,7 +3352,7 @@
     "istanbul": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "integrity": "sha512-nMtdn4hvK0HjUlzr1DrKSUY8ychprt8dzHOgY2KXsIhHu5PuQQEOTM27gV9Xblyon7aUH/TSFIjRHEODF/FRPg==",
       "requires": {
         "abbrev": "1.0.x",
         "async": "1.x",
@@ -3587,6 +3368,26 @@
         "supports-color": "^3.1.0",
         "which": "^1.1.1",
         "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A=="
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA=="
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "javascript-state-machine": {
@@ -3594,20 +3395,19 @@
       "resolved": "https://registry.npmjs.org/javascript-state-machine/-/javascript-state-machine-3.1.0.tgz",
       "integrity": "sha512-BwhYxQ1OPenBPXC735RgfB+ZUG8H3kjsx8hrYTgWnoy6TPipEy4fiicyhT2lxRKAXq9pG7CfFT8a2HLr6Hmwxg=="
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "optional": true
+    },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
-        }
       }
     },
     "jsbn": {
@@ -3631,6 +3431,16 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
@@ -3639,7 +3449,7 @@
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -3654,9 +3464,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -3674,7 +3484,7 @@
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3684,7 +3494,7 @@
     "jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -3693,15 +3503,29 @@
     "key-tree-store": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/key-tree-store/-/key-tree-store-1.3.0.tgz",
-      "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
+      "integrity": "sha512-qXk+lR+LXvGos3wqMxIMWweKDgCx8ZKWM6BEPm7iZkOKug5ggi66vUt+3vbtKJLBrAyOxQ4S8JRwK++Q4XZRmw=="
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "optional": true,
+      "requires": {
+        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -3712,17 +3536,17 @@
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+      "integrity": "sha512-RHShTDnPKP7aWxlvXKiDT6IX2jCs6YZLCtNhOru/OX2Q/tzX295vVBK5oX1ECtN+2r86S0Ogy8ykP1sgCZAN0A=="
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+      "integrity": "sha512-Mn7HidOVcl3mkQtbPsuKR0Fj0N6Q6DQB77CtYncZcJc0bx5qv2q4Gl6a0LC1AN+GSxpnBDNnK3CKEm9XNA4zqQ=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
       "requires": {
         "lodash._basecopy": "^3.0.0",
         "lodash.keys": "^3.0.0"
@@ -3731,7 +3555,7 @@
     "lodash._baseclone": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "integrity": "sha512-1K0dntf2dFQ5my0WoGKkduewR6+pTNaqX03kvs45y7G5bzl4B3kTR4hDfJIc2aCQDeLyQHhS280tc814m1QC1Q==",
       "requires": {
         "lodash._arraycopy": "^3.0.0",
         "lodash._arrayeach": "^3.0.0",
@@ -3744,22 +3568,22 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+      "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ=="
     },
     "lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+      "integrity": "sha512-6bc3b8grkpMgDcVJv9JYZAk/mHgcqMljzm7OsbmcE2FGUMmmLQTPHlh/dFqR8LA0GQ7z4K67JSotVKu5058v1A=="
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ=="
     },
     "lodash._createassigner": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "integrity": "sha512-LziVL7IDnJjQeeV95Wvhw6G28Z8Q6da87LWKOPWmzBLv4u6FAT/x5v00pyGW0u38UoogNF2JnD3bGgZZDaNEBw==",
       "requires": {
         "lodash._bindcallback": "^3.0.0",
         "lodash._isiterateecall": "^3.0.0",
@@ -3769,17 +3593,17 @@
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA=="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+      "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ=="
     },
     "lodash.assign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+      "integrity": "sha512-/VVxzgGBmbphasTg51FrztxQJ/VgAUpol6zmJuSVSGcNg4g7FA4z7rQV8Ovr9V3vFBNWZhvKWHfpAytjTVUfFA==",
       "requires": {
         "lodash._baseassign": "^3.0.0",
         "lodash._createassigner": "^3.0.0",
@@ -3787,118 +3611,83 @@
       }
     },
     "lodash.clone": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+      "integrity": "sha512-yVYPpFTdZDCLG2p07gVRTvcwN5X04oj2hu4gG6r0fer58JA08wAVxXzWM+CmmxO2bzOH8u8BkZTZqgX6juVF7A==",
+      "requires": {
+        "lodash._baseclone": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "integrity": "sha512-I8MpGh5z+6OixDAAb21teLSZDmqVPjlq02Q7ZFrbn2xnQHYYuJf6on/94SWpF/p0s3p/cEv/53ro4AhDOfCR0g==",
       "requires": {
         "lodash._baseclone": "^3.0.0",
         "lodash._bindcallback": "^3.0.0"
       }
     },
-    "lodash.fill": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.fill/-/lodash.fill-3.4.0.tgz",
-      "integrity": "sha1-o8dK5kDQU63w3CB5+HIHiOi/74U="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.intersection": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
-      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ=="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
       "requires": {
         "lodash._getnative": "^3.0.0",
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
     },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-    },
-    "lodash.partialright": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
-      "integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+      "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw=="
     },
     "log": {
       "version": "1.4.0",
@@ -3906,9 +3695,18 @@
       "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
     "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "optional": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -3920,23 +3718,187 @@
       }
     },
     "ltx": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
-      "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.10.0.tgz",
+      "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "mattermost-client": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.1.0.tgz",
-      "integrity": "sha1-cw5BLw8BTvq2GiHbKN8S8gqIgSY=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/mattermost-client/-/mattermost-client-6.5.0.tgz",
+      "integrity": "sha512-4Nqg8k3lF/Mr5DGt3s0cZfNm+hF/YTKaIDVQJNGuB0TiaE7/BSJMcpwKdoBjz4ztruWNaV+oBAofrUILwT1EcA==",
       "requires": {
-        "https-proxy-agent": "^2.1.0",
-        "log": "^1.4.0",
-        "request": "^2.73.0",
-        "text-encoding": "^0.5.5",
-        "ws": "^1.0.1"
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "log": "^6.1.0",
+        "request": "^2.88.0",
+        "set-value": ">=4.0.1",
+        "text-encoding": "^0.7.0",
+        "ws": ">=3.3.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "aws4": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "har-validator": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+          "requires": {
+            "ajv": "^6.12.3",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "log": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
+          "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
+          "requires": {
+            "d": "^1.0.1",
+            "duration": "^0.2.2",
+            "es5-ext": "^0.10.53",
+            "event-emitter": "^0.3.5",
+            "sprintf-kit": "^2.0.1",
+            "type": "^2.5.0",
+            "uni-global": "^1.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+          "requires": {
+            "mime-db": "1.52.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "punycode": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "ws": {
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
+        }
       }
     },
     "md5": {
@@ -3959,10 +3921,26 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "optional": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "optional": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -3985,7 +3963,7 @@
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -3999,29 +3977,22 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.6"
       }
     },
     "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha1-KhFLUdKm7J5tg8+AP4OKh42KAjo="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.0.0",
@@ -4029,24 +4000,26 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "ms-rest": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.4.tgz",
-      "integrity": "sha512-VeqCbawxRM6nhw0RKNfj7TWL7SL8PB6MypqwgylXCi+u412uvYoyY/kSmO8n06wyd8nIcnTbYToCmSKFMI1mCg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.6.tgz",
+      "integrity": "sha512-3Scy/pF43wqPEPeJxhOsLs16m6Rt+9zqf+jKdg+guuonytKmFSxerQM2exlQIDTqFVTsLXrPEGFWTGSwivRRkA==",
       "requires": {
+        "ajv": "6.12.3",
         "duplexer": "^0.1.1",
+        "http-signature": "1.3.6",
         "is-buffer": "^1.1.6",
         "is-stream": "^1.1.0",
         "moment": "^2.21.0",
-        "request": "^2.88.0",
+        "request": "^2.88.2",
         "through": "^2.3.8",
         "tunnel": "0.0.5",
         "uuid": "^3.2.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -4055,9 +4028,9 @@
           }
         },
         "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+          "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
         },
         "extend": {
           "version": "3.0.2",
@@ -4065,17 +4038,27 @@
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+          "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^2.0.2",
+            "sshpk": "^1.14.1"
           }
         },
         "json-schema-traverse": {
@@ -4083,17 +4066,28 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
+        "jsprim": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+          "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.4.0",
+            "verror": "1.10.0"
+          }
+        },
         "mime-db": {
-          "version": "1.43.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-          "version": "2.1.26",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-          "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
           "requires": {
-            "mime-db": "1.43.0"
+            "mime-db": "1.52.0"
           }
         },
         "oauth-sign": {
@@ -4102,9 +4096,9 @@
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "request": {
           "version": "2.88.2",
@@ -4133,6 +4127,27 @@
             "uuid": "^3.3.2"
           },
           "dependencies": {
+            "http-signature": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+              "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+              "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+              }
+            },
+            "jsprim": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+              "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.4.0",
+                "verror": "1.10.0"
+              }
+            },
             "uuid": {
               "version": "3.4.0",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -4150,6 +4165,11 @@
           }
         }
       }
+    },
+    "msrcrypto": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/msrcrypto/-/msrcrypto-1.5.8.tgz",
+      "integrity": "sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q=="
     },
     "multiparty": {
       "version": "4.2.3",
@@ -4195,118 +4215,97 @@
         }
       }
     },
-    "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "optional": true
-    },
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
-    "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
-    "node-icu-charset-detector": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/node-icu-charset-detector/-/node-icu-charset-detector-0.2.0.tgz",
-      "integrity": "sha1-wjINo3Tdy2cfxUy0oOBB4Vb/1jk=",
-      "optional": true,
-      "requires": {
-        "nan": "^2.3.3"
-      }
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+    },
+    "node-gyp-build": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
+      "integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg=="
     },
     "node-jose": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-0.11.1.tgz",
-      "integrity": "sha512-1mX5prmancKdOgMI/85uduqWNFg63traxVdun7dNNsX4AUs6HqztJhzfBlIWfSujQ8Rah9dWLGUFlXORxZvvzg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.2.0.tgz",
+      "integrity": "sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw==",
       "requires": {
-        "b64u": "^2.0.0",
-        "es6-promise": "^4.0.5",
-        "lodash.assign": "^4.0.8",
-        "lodash.clone": "^4.3.2",
-        "lodash.fill": "^3.2.2",
-        "lodash.flatten": "^4.2.0",
-        "lodash.intersection": "^4.1.2",
-        "lodash.merge": "^4.3.5",
-        "lodash.omit": "^4.2.1",
-        "lodash.partialright": "^4.1.3",
-        "lodash.pick": "^4.2.0",
-        "lodash.uniq": "^4.2.1",
-        "long": "^3.1.0",
-        "node-forge": "^0.7.1",
-        "uuid": "^3.0.1"
+        "base64url": "^3.0.1",
+        "buffer": "^6.0.3",
+        "es6-promise": "^4.2.8",
+        "lodash": "^4.17.21",
+        "long": "^5.2.0",
+        "node-forge": "^1.2.1",
+        "pako": "^2.0.4",
+        "process": "^0.11.10",
+        "uuid": "^9.0.0"
       },
       "dependencies": {
-        "lodash.assign": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+        "es6-promise": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         }
       }
     },
     "node-kms": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.3.2.tgz",
-      "integrity": "sha1-beflJICO7ATHf+6072SUDlDit1k=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.4.0.tgz",
+      "integrity": "sha512-Tvhs7XTvBgWLZUrAeLKDqzvlomaZWwMoIXWImMc/IbvTijLoOrkovZo+PeW0ivf/8fBlg5EihPCwKg/dy9r+sA==",
       "requires": {
         "es6-promise": "^2.0.1",
         "lodash.clone": "^3.0.2",
         "lodash.clonedeep": "^3.0.1",
-        "node-jose": ">=0.3.0 <1.0",
+        "node-jose": "^2.0.0",
         "uuid": "^2.0.1"
       },
       "dependencies": {
         "es6-promise": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
-        },
-        "lodash.clone": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
-          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
-          "requires": {
-            "lodash._baseclone": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
-          }
+          "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
         },
         "uuid": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+          "integrity": "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg=="
         }
       }
     },
     "node-scr": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.2.2.tgz",
-      "integrity": "sha1-VCqtdCAQ0S5Bm1kG2lFq+d6jBdo=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.3.0.tgz",
+      "integrity": "sha512-Hb0ykojynSbt7ra6eml6NX39WAumFfU3G81XvLpp2H7y8KjQc29oEIf2TlgZQCfA+pyxbY5t4a1xBqPpyrbpvw==",
       "requires": {
         "es6-promise": "^2.0.1",
         "lodash.clone": "^3.0.2",
-        "node-jose": ">=0.3.0 <1.0"
+        "node-jose": "^2.0.0"
       },
       "dependencies": {
         "es6-promise": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
-        },
-        "lodash.clone": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
-          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
-          "requires": {
-            "lodash._baseclone": "^3.0.0",
-            "lodash._bindcallback": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0"
-          }
+          "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw=="
         }
       }
     },
@@ -4318,7 +4317,7 @@
     "node-xmpp-client": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.0.0.tgz",
-      "integrity": "sha1-UsxdO/fR/IbSd2pYL3x7yugCYTo=",
+      "integrity": "sha512-evWWdIBMx5AzNmj0CkCwlhosRACRTWC4W4rnhUHg1MZPmqfsIl/WPHTwQfwnQE0xL0+EUcVkUJigOzolmHfI9Q==",
       "requires": {
         "browser-request": "^0.3.3",
         "debug": "^2.2.0",
@@ -4332,7 +4331,7 @@
         "faye-websocket": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+          "integrity": "sha512-Xhj93RXbMSq8urNCUq4p9l0P6hnySJ/7YNRhYNug0bLOuii7pKO7xQFb5mx9xZXWCar88pLPb805PvUkwrLZpQ==",
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
@@ -4342,7 +4341,7 @@
     "node-xmpp-core": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-core/-/node-xmpp-core-4.2.0.tgz",
-      "integrity": "sha1-fi4EDB5apkvjUBO9w0Ey7Ddpla4=",
+      "integrity": "sha512-ZugTIR0OU3Q23b7rcsHzvxfmfjZ7+khQcWm5r+5i1kxrs85eIan2ahsUp2LtSDBzcYk+8CqDgSKh+MYue08oXg==",
       "requires": {
         "debug": "^2.2.0",
         "inherits": "^2.0.1",
@@ -4356,12 +4355,12 @@
     "node-xmpp-jid": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-xmpp-jid/-/node-xmpp-jid-2.3.0.tgz",
-      "integrity": "sha1-YKPJUFgqDNz9oHRJQ1eoUXjziHg="
+      "integrity": "sha512-jSmRnpbc0brF9baWg9QZQzhyNNkobGsw0zAymWl0hsIb+CsaPpZboWJ+NGeHq89XwqC6udJjwMiUDZM3tqqFLw=="
     },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
       "requires": {
         "abbrev": "1"
       }
@@ -4400,43 +4399,22 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-        }
-      }
-    },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "options": {
@@ -4457,35 +4435,75 @@
         "url-parse": "^1.4.3"
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "optional": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "optional": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "parent-require": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
       "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
     },
     "parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "optional": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "optional": true
     },
     "pkginfo": {
       "version": "0.4.1",
@@ -4493,9 +4511,14 @@
       "integrity": "sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ=="
     },
     "pkijs": {
-      "version": "2.1.88",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.1.88.tgz",
-      "integrity": "sha512-R/1VglrBioIx3wdX1/DzEcJDvhJgl5cNsT+Ovex3zWbCwjY2mDUW2Qvj6/kc0S7PDDnijXwHczAVRYscNLhUgQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.4.0.tgz",
+      "integrity": "sha512-cjJP/mYuGyMrjJ49jI04khId5Oufd3nFTUYBzQTIIVNI7/oAWdwXEfpwTF8HELFV/gz+WGYUBHCe3KHWD8rYvg==",
+      "requires": {
+        "asn1js": "^3.0.3",
+        "bytestreamjs": "^1.0.29",
+        "pvutils": "^1.1.3"
+      },
       "dependencies": {
         "asn1js": {
           "version": "3.0.5",
@@ -4506,46 +4529,28 @@
             "pvutils": "^1.1.3",
             "tslib": "^2.4.0"
           }
-        },
-        "bytestreamjs": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
-          "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ=="
-        },
-        "pvtsutils": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-          "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        },
-        "pvutils": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-          "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -4565,9 +4570,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
       "version": "1.4.1",
@@ -4575,12 +4580,17 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "pvtsutils": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.10.tgz",
-      "integrity": "sha512-8ZKQcxnZKTn+fpDh7wL4yKax5fdl3UJzT8Jv49djZpB/dzPxacyN1Sez90b6YLdOmvIr9vaySJ5gw4aUA1EdSw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
       "requires": {
-        "tslib": "^1.10.0"
+        "tslib": "^2.6.1"
       }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
     "q": {
       "version": "1.5.1",
@@ -4596,6 +4606,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "optional": true
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -4657,6 +4673,15 @@
         }
       }
     },
+    "react-native-securerandom": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz",
+      "integrity": "sha512-CozcCx0lpBLevxiXEb86kwLRalBCHNjiGPlw3P7Fi27U6ZLdfjOCNRHD1LtBKcvPvI3TvkBXB3GOtLvqaYJLGw==",
+      "optional": true,
+      "requires": {
+        "base64-js": "*"
+      }
+    },
     "readable-stream": {
       "version": "1.0.34",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -4668,17 +4693,57 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "reconnect-core": {
       "version": "https://github.com/dodo/reconnect-core/tarball/merged",
-      "integrity": "sha1-udryrcRbGabMX9LwSPjZQGzs5Jg=",
+      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
       "requires": {
         "backoff": "~2.3.0"
+      },
+      "dependencies": {
+        "backoff": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
+          "integrity": "sha512-ljr33cUQ/vyXE/60QuRO+WKGW4PzQ5OTWNXPWQwOTx5gh43q0pZocaVyXoU2gvFtasMIdIohdm9s01qoT6IJBQ=="
+        }
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "request": {
       "version": "2.85.0",
@@ -4717,22 +4782,54 @@
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
     },
     "retry": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz",
       "integrity": "sha512-bkzdIZ5Xyim12j0jq6CQAHpfdsa2VqieWF6eN8vT2MXxCxLAZhgVUyu5EEMevJyXML+XWTxVbZ7mLaKx5F/DZw=="
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "optional": true
+    },
     "rsa-pem-from-mod-exp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
-      "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.6.tgz",
+      "integrity": "sha512-c5ouQkOvGHF1qomUUDJGFcXsomeSO2gbEs6hVhMAtlkE1CuaZase/WzoaKFG/EZQuNmq6pw/EMCeEnDvOgCJYQ=="
     },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+    },
+    "rtcpeerconnection-shim": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
+      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
+      "requires": {
+        "sdp": "^2.6.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "optional": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -4744,10 +4841,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sdp": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
+      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
+    },
     "sdp-transform": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.0.tgz",
-      "integrity": "sha512-8ZYOau/o9PzRhY0aMuRzvmiM6/YVQR8yjnBScvZHSdBnywK5oZzAJK+412ZKkDq29naBmR3bRw8MFu0C01Gehg=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
+      "integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw=="
     },
     "semver": {
       "version": "5.7.2",
@@ -4848,6 +4950,15 @@
         "has-property-descriptors": "^1.0.0"
       }
     },
+    "set-value": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "is-primitive": "^3.0.1"
+      }
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -4859,13 +4970,6 @@
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "requires": {
         "kind-of": "^6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-        }
       }
     },
     "side-channel": {
@@ -4889,16 +4993,24 @@
     "source-map": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
       "optional": true,
       "requires": {
         "amdefine": ">=0.0.4"
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "sprintf-kit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
+      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
+      "requires": {
+        "es5-ext": "^0.10.53"
+      }
     },
     "sshpk": {
       "version": "1.14.1",
@@ -4936,6 +5048,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
     },
+    "str2buf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/str2buf/-/str2buf-1.3.0.tgz",
+      "integrity": "sha512-xIBmHIUHYZDP4HyoXGHYNVmxlXLXDrtFHYT0eV6IOdEj3VO9ccaF1Ejl9Oq8iFjITllpT8FhaXb4KsNmw+3EuA=="
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -4954,28 +5071,38 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+    "strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "requires": {
-        "has-flag": "^1.0.0"
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "optional": true,
+      "requires": {
+        "has-flag": "^4.0.0"
       }
     },
     "text-encoding": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.5.5.tgz",
-      "integrity": "sha1-0phF2cHyrFzrpL+GHFYYVsUjrFM="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "through2": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
       "requires": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
@@ -4984,12 +5111,30 @@
     "tls-connect": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/tls-connect/-/tls-connect-0.2.2.tgz",
-      "integrity": "sha1-HYjU9MuCmgdBtqzQXR33Pg1Wb9A="
+      "integrity": "sha512-iV92SmsU+iB+TZKeZxBRTyk8T0RAXDjpwoYjG28HMm5E0ilPfrfqidDntRL4ZswoqRv81Kx05PqbK6CN7olrKQ=="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "optional": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
     },
     "tough-cookie": {
       "version": "2.3.4",
@@ -5007,12 +5152,12 @@
     "tsc": {
       "version": "1.20150623.0",
       "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU="
+      "integrity": "sha512-35dAbChm97r03rxlfPwkFrrI8WoFlrqtbskmxomtnso2fOSKWDLt3TitT2ZNHl5hQF1Su9S9w/vjmoXf5W0VWA=="
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel": {
       "version": "0.0.5",
@@ -5033,10 +5178,15 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -5065,10 +5215,18 @@
         }
       }
     },
+    "typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "requires": {
+        "rxjs": "*"
+      }
+    },
     "uglify-js": {
-      "version": "3.13.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
-      "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "optional": true
     },
     "uid-safe": {
@@ -5084,23 +5242,37 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
+    "uni-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
+      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
+      "requires": {
+        "type": "^2.5.0"
+      }
+    },
+    "universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "optional": true
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         }
       }
     },
@@ -5121,7 +5293,20 @@
     "urlsafe-base64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
-      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
+      "integrity": "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="
+    },
+    "utf-8-validate": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.3.tgz",
+      "integrity": "sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -5136,7 +5321,7 @@
     "valid-url": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "vary": {
       "version": "1.1.2",
@@ -5154,49 +5339,70 @@
       }
     },
     "webcrypto-core": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.0.19.tgz",
-      "integrity": "sha512-6XHExtfMJrpkFDh9MiJ/y7ptX0dfZi0ogxFyelqxMu1eFowxivHfIp6DKzT+ZjU66xTuNfJkfkUk1bIB3tEOgA==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
       "requires": {
-        "@peculiar/asn1-schema": "^1.0.5",
-        "@peculiar/json-schema": "^1.1.10",
-        "asn1js": "^2.0.26",
-        "pvtsutils": "^1.0.10",
-        "tslib": "^1.11.1"
-      }
-    },
-    "webex": {
-      "version": "1.80.178",
-      "resolved": "https://registry.npmjs.org/webex/-/webex-1.80.178.tgz",
-      "integrity": "sha512-DNMYNMPlZqRF1IrwjAmThw2jc7mtV44mz+CzMoH92UGRVYoLaDoO/kxb0nZ8NNiiH99ciUbjnGRNnJ0wa/hX4A==",
-      "requires": {
-        "@webex/internal-plugin-calendar": "1.80.178",
-        "@webex/internal-plugin-device": "1.80.178",
-        "@webex/internal-plugin-presence": "1.80.178",
-        "@webex/plugin-attachment-actions": "1.80.178",
-        "@webex/plugin-authorization": "1.80.178",
-        "@webex/plugin-device-manager": "1.80.178",
-        "@webex/plugin-logger": "1.80.178",
-        "@webex/plugin-meetings": "1.80.178",
-        "@webex/plugin-memberships": "1.80.178",
-        "@webex/plugin-messages": "1.80.178",
-        "@webex/plugin-people": "1.80.178",
-        "@webex/plugin-rooms": "1.80.178",
-        "@webex/plugin-team-memberships": "1.80.178",
-        "@webex/plugin-teams": "1.80.178",
-        "@webex/plugin-webhooks": "1.80.178",
-        "@webex/storage-adapter-local-storage": "1.80.178",
-        "@webex/webex-core": "1.80.178",
-        "babel-polyfill": "^6.26.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.15"
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        "asn1js": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+          "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+          "requires": {
+            "pvtsutils": "^1.3.2",
+            "pvutils": "^1.1.3",
+            "tslib": "^2.4.0"
+          }
         }
+      }
+    },
+    "webcrypto-shim": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
+      "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
+    },
+    "webex": {
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-1.161.0.tgz",
+      "integrity": "sha512-fEheKltkfHrZCNHtZPHZjLPicb47JiKQzKcO/J+26n6snYsLnmhU0y8BHsbWkuudD1RuXZV/kFBSd6/nzWFO4w==",
+      "requires": {
+        "@babel/polyfill": "^7.12.1",
+        "@babel/runtime-corejs2": "^7.14.8",
+        "@webex/internal-plugin-calendar": "1.161.0",
+        "@webex/internal-plugin-device": "1.161.0",
+        "@webex/internal-plugin-presence": "1.161.0",
+        "@webex/internal-plugin-support": "1.161.0",
+        "@webex/plugin-attachment-actions": "1.161.0",
+        "@webex/plugin-authorization": "1.161.0",
+        "@webex/plugin-device-manager": "1.161.0",
+        "@webex/plugin-logger": "1.161.0",
+        "@webex/plugin-meetings": "1.161.0",
+        "@webex/plugin-memberships": "1.161.0",
+        "@webex/plugin-messages": "1.161.0",
+        "@webex/plugin-people": "1.161.0",
+        "@webex/plugin-rooms": "1.161.0",
+        "@webex/plugin-team-memberships": "1.161.0",
+        "@webex/plugin-teams": "1.161.0",
+        "@webex/plugin-webhooks": "1.161.0",
+        "@webex/storage-adapter-local-storage": "1.161.0",
+        "@webex/webex-core": "1.161.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "webrtc-adapter": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
+      "integrity": "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==",
+      "requires": {
+        "rtcpeerconnection-shim": "^1.2.15",
+        "sdp": "^2.12.0"
       }
     },
     "websocket-driver": {
@@ -5214,9 +5420,9 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -5241,15 +5447,20 @@
         }
       }
     },
+    "word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
       "version": "1.1.5",
@@ -5269,6 +5480,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "hubot-diagnostics": "0.0.2",
     "hubot-flowdock": "^0.7.8",
     "hubot-help": "^0.2.2",
-    "hubot-irc": "^0.4.2",
+    "hubot-irc": "0.4.0",
     "hubot-matteruser": "^5.4.6",
     "hubot-redis-brain": "0.0.4",
     "hubot-rocketchat": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "StackStorm <support@stackstorm.com>",
   "description": "A simple helpful robot for your Company, with StackStorm Support",
   "dependencies": {
-    "botbuilder": "^3.30.0",
+    "botbuilder": "^3.16.0",
     "coffee-register": "1.0.0",
     "coffee-script": "1.12.7",
     "hubot": "^3.5.0",
@@ -14,15 +14,15 @@
     "hubot-diagnostics": "0.0.2",
     "hubot-flowdock": "^0.7.8",
     "hubot-help": "^0.2.2",
-    "hubot-irc": "^0.4.2",
-    "hubot-matteruser": "^5.4.6",
+    "hubot-irc": "^0.4.0",
+    "hubot-matteruser": "^5.2.0",
     "hubot-redis-brain": "0.0.4",
     "hubot-rocketchat": "^2.0.0",
     "hubot-scripts": "^2.17.2",
     "hubot-slack": "^4.10.0",
     "hubot-spark": "git+https://github.com/tonybaloney/hubot-spark.git#c440504",
     "hubot-stackstorm": "^0.12.0",
-    "hubot-xmpp": "^0.2.6"
+    "hubot-xmpp": "^0.2.5"
   },
   "engines": {
     "node": ">=10.0 <=14.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "StackStorm <support@stackstorm.com>",
   "description": "A simple helpful robot for your Company, with StackStorm Support",
   "dependencies": {
-    "botbuilder": "^3.16.0",
+    "botbuilder": "^3.30.0",
     "coffee-register": "1.0.0",
     "coffee-script": "1.12.7",
     "hubot": "^3.5.0",
@@ -14,15 +14,15 @@
     "hubot-diagnostics": "0.0.2",
     "hubot-flowdock": "^0.7.8",
     "hubot-help": "^0.2.2",
-    "hubot-irc": "^0.4.0",
-    "hubot-matteruser": "^5.2.0",
+    "hubot-irc": "^0.4.2",
+    "hubot-matteruser": "^5.4.6",
     "hubot-redis-brain": "0.0.4",
     "hubot-rocketchat": "^2.0.0",
     "hubot-scripts": "^2.17.2",
     "hubot-slack": "^4.10.0",
     "hubot-spark": "git+https://github.com/tonybaloney/hubot-spark.git#c440504",
     "hubot-stackstorm": "^0.12.0",
-    "hubot-xmpp": "^0.2.5"
+    "hubot-xmpp": "^0.2.6"
   },
   "engines": {
     "node": ">=10.0 <=14.0"

--- a/package.json
+++ b/package.json
@@ -6,23 +6,23 @@
   "author": "StackStorm <support@stackstorm.com>",
   "description": "A simple helpful robot for your Company, with StackStorm Support",
   "dependencies": {
-    "botbuilder": "^3.16.0",
+    "botbuilder": "^3.30.0",
     "coffee-register": "1.0.0",
     "coffee-script": "1.12.7",
-    "hubot": "^3.1.1",
+    "hubot": "^3.5.0",
     "hubot-botframework": "git+https://github.com/microsoft/BotFramework-Hubot.git#01d5be9",
     "hubot-diagnostics": "0.0.2",
     "hubot-flowdock": "^0.7.8",
     "hubot-help": "^0.2.2",
-    "hubot-irc": "^0.4.0",
-    "hubot-matteruser": "^5.2.0",
+    "hubot-irc": "^0.4.2",
+    "hubot-matteruser": "^5.4.6",
     "hubot-redis-brain": "0.0.4",
     "hubot-rocketchat": "^2.0.0",
     "hubot-scripts": "^2.17.2",
     "hubot-slack": "^4.10.0",
     "hubot-spark": "git+https://github.com/tonybaloney/hubot-spark.git#c440504",
     "hubot-stackstorm": "^0.12.0",
-    "hubot-xmpp": "^0.2.5"
+    "hubot-xmpp": "^0.2.6"
   },
   "engines": {
     "node": ">=10.0 <=14.0"


### PR DESCRIPTION
Second stage to update upstream dependencies https://github.com/StackStorm/st2chatops/issues/133

A follow-up to https://github.com/StackStorm/st2chatops/pull/183 which updates dependencies minimally via `npm audit fix`, this PR updates things in a more radical way via `npm update`.

Before:
```
found 180 vulnerabilities (12 low, 92 moderate, 52 high, 24 critical) in 668 scanned packages
```

After:
```
added 136 packages from 120 contributors, removed 143 packages, updated 218 packages, moved 9 packages and audited 700 packages in 885.083s

found 87 vulnerabilities (69 moderate, 16 high, 2 critical)
```

This may potentially break things, so creating a dedicated PR in case if we'll need to revert it in the future (after e2e st2chatops tests).