### PR TITLE
Node 20 and EL9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
           rm -rf node_modules
-          npm install npm@6
           # print versions
           docker-compose version
           nodejs -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,11 @@ jobs:
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
           rm -rf node_modules
+          npm install npm@6
           # print versions
           docker-compose version
           nodejs -v
+          npm --version
           jq --version
     - run:
         name: Ensure Docker running

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ jobs:
     machine:
       image: "ubuntu-2204:2023.04.2"
     working_directory: ~/StackStorm/st2chatops
-    parallelism: 2
+    parallelism: 3
     shell: /bin/bash --login
     environment:
-      DISTROS: focal el8
+      DISTROS: focal el8 el9
       ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
       ST2_TEST_ENVIRONMENT: https://github.com/StackStorm/st2-docker
       DEPLOY_PACKAGES: 1
@@ -122,7 +122,7 @@ jobs:
       - image: circleci/ruby:2.7
     working_directory: ~/packages
     environment:
-      DISTROS: "focal el8"
+      DISTROS: "focal el8 el9"
     steps:
       - attach_workspace:
           at: /home/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           echo "Cloning ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} branch of st2-docker"
           git clone --branch ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
           make -C ~/st2-docker env
-          sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs net-tools
+          sudo apt-get update -qq && sudo apt-get install -y rpm jq nodejs net-tools npm
           gem install package_cloud
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Added
 * A changelog file.
 
     Contributed by @nzlosh
+* EL9 support and node20 support
+
+    Contributed by @amanda11
 
 Fixed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:20.11.1-slim
 
 RUN apt update && apt install --yes \
   python \
+  npm \
   libicu-dev \
   libxml2-dev \
   libexpat1-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-slim
+FROM node:20.11.1-slim
 
 RUN apt update && apt install --yes \
   python \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20.11.1-slim
 
 RUN apt update && apt install --yes \
-  python \
+  python3 \
   npm \
   libicu-dev \
   libxml2-dev \
@@ -12,6 +12,7 @@ RUN apt update && apt install --yes \
 
 COPY . /app
 WORKDIR /app
+RUN npm install npm@6 -g
 RUN npm install --production && npm cache verify
 
 RUN apt remove --yes \

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/stackstorm/st2chatops
 Package: st2chatops
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.16)
-Depends: nodejs (>= 10.0.0), nodejs (< 15.0.0)
+Depends: nodejs (>= 20.0.0)
 Description: St2Chatops - StackStorm ChatOps.
  Package providing StackStorm ChatOps functionality: bundled, tested and ready to use Hubot
  with hubot-stackstorm plugin and additional chat adapters

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15-slim
+FROM node:20.11.1-slim
 
 RUN apt-get update && apt-get install -y \
   python \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@ el8:
     file: docker-compose.override.yml
     service: suite
 
+el9:
+  build: ./packagingenv/rockylinux9
+  extends:
+    file: docker-compose.override.yml
+    service: suite
+
 # Testing environments
 focal-test:
   build: ./testingenv/focal
@@ -20,6 +26,12 @@ focal-test:
 
 el8-test:
   build: ./testingenv/rockylinux8
+  extends:
+    file: docker-compose.override.yml
+    service: suite-test
+
+el9-test:
+  build: ./testingenv/rockylinux9
   extends:
     file: docker-compose.override.yml
     service: suite-test

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "botbuilder": "^3.30.0",
     "coffee-register": "1.0.0",
     "coffee-script": "1.12.7",
+    "coffeescript": "1.12.7",
     "hubot": "^3.5.0",
     "hubot-botframework": "git+https://github.com/microsoft/BotFramework-Hubot.git#01d5be9",
     "hubot-diagnostics": "0.0.2",
@@ -25,6 +26,6 @@
     "hubot-xmpp": "^0.2.6"
   },
   "engines": {
-    "node": ">=10.0 <=14.0"
+    "node": ">=20.0"
   }
 }

--- a/packagingenv/Dockerfile.template
+++ b/packagingenv/Dockerfile.template
@@ -4,6 +4,10 @@ FROM {{ dist }}:{{ version }}
 
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
+{%- if version in ('centos9', 'rockylinux9') %}
+RUN yum -y install systemd-rpm-macros
+{% endif %}
+
 # Add NodeSource repo
 #RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 

--- a/packagingenv/Dockerfile.template
+++ b/packagingenv/Dockerfile.template
@@ -5,7 +5,7 @@ FROM {{ dist }}:{{ version }}
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
 # Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
+RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 {%- if version in ('centos8', 'rockylinux8') %}
 

--- a/packagingenv/Dockerfile.template
+++ b/packagingenv/Dockerfile.template
@@ -8,9 +8,6 @@ RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 RUN yum -y install systemd-rpm-macros
 {% endif %}
 
-# Add NodeSource repo
-#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
-
 # Install node
 RUN yum -y module install nodejs:20
 

--- a/packagingenv/Dockerfile.template
+++ b/packagingenv/Dockerfile.template
@@ -5,23 +5,19 @@ FROM {{ dist }}:{{ version }}
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
 # Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
-
-{%- if version in ('centos8', 'rockylinux8') %}
+#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install node
-RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && \
-    source ~/.bashrc && \
-    nvm install 20.8.1 && \
-    node -v && npm -v
+RUN yum -y module install nodejs:20
 
 # Install python3 for gyp
 RUN yum -y install python3
 
 # Upgrade gyp to a python3 compatible version
-RUN source ~/.bashrc && nvm use 20.8.1 && npm install -g node-gyp@latest
+RUN npm install -g node-gyp@latest
 
-{%- endif %}
+# Downgrade npm
+RUN npm install -g npm@6
 
 # Install node
 RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && \
@@ -40,10 +36,15 @@ RUN apt-get update && \
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd
 {% endif %}
 
-RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash - && \
-    . ~/.bashrc && \
-    nvm install 20.8.1 && \
-    node -v && npm -v
+# Add NodeSource repo
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
+
+# Install node
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs
+
+RUN apt-get clean
+RUN npm install -g npm@6
+
 
 {% endif -%}
 

--- a/packagingenv/Dockerfile.template
+++ b/packagingenv/Dockerfile.template
@@ -9,38 +9,41 @@ RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 {%- if version in ('centos8', 'rockylinux8') %}
 
-# Install development tools
-RUN yum -y module install nodejs:10
+# Install node
+RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && \
+    source ~/.bashrc && \
+    nvm install 20.8.1 && \
+    node -v && npm -v
 
 # Install python3 for gyp
 RUN yum -y install python3
 
 # Upgrade gyp to a python3 compatible version
-RUN npm install -g node-gyp@latest
+RUN source ~/.bashrc && nvm use 20.8.1 && npm install -g node-gyp@latest
 
 {%- endif %}
 
-# Install development tools
-RUN yum -y install nodejs
+# Install node
+RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && \
+    source ~/.bashrc && \
+    nvm install 20.8.1 && \
+    node -v && npm -v
 
 {% else -%}
 
 # Install prerequisites
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    build-essential curl gnupg devscripts debhelper dh-make git libicu-dev
+    build-essential curl gnupg devscripts debhelper dh-make git libicu-dev curl
 
 {%- if version in ('focal') %}
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd
 {% endif %}
 
-# Add NodeSource repo
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-
-# Install node
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs
-
-RUN apt-get clean
+RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash - && \
+    . ~/.bashrc && \
+    nvm install 20.8.1 && \
+    node -v && npm -v
 
 {% endif -%}
 

--- a/packagingenv/focal/Dockerfile
+++ b/packagingenv/focal/Dockerfile
@@ -6,11 +6,14 @@ RUN apt-get update && \
     build-essential curl gnupg devscripts debhelper dh-make git libicu-dev curl
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd
 
+# Add NodeSource repo
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
-RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash - && \
-    . ~/.bashrc && \
-    nvm install 20.8.1 && \
-    node -v && npm -v
+# Install node
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs
+
+RUN apt-get clean
+
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packagingenv/focal/Dockerfile
+++ b/packagingenv/focal/Dockerfile
@@ -13,6 +13,7 @@ RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs
 
 RUN apt-get clean
+RUN npm install -g npm@6
 
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/packagingenv/focal/Dockerfile
+++ b/packagingenv/focal/Dockerfile
@@ -3,17 +3,14 @@ FROM ubuntu:focal
 # Install prerequisites
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    build-essential curl gnupg devscripts debhelper dh-make git libicu-dev
+    build-essential curl gnupg devscripts debhelper dh-make git libicu-dev curl
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd
 
 
-# Add NodeSource repo
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-
-# Install node
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs
-
-RUN apt-get clean
+RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash - && \
+    . ~/.bashrc && \
+    nvm install 20.8.1 && \
+    node -v && npm -v
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packagingenv/focal/Dockerfile
+++ b/packagingenv/focal/Dockerfile
@@ -8,7 +8,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd
 
 
 # Add NodeSource repo
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
 # Install node
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs

--- a/packagingenv/rockylinux8/Dockerfile
+++ b/packagingenv/rockylinux8/Dockerfile
@@ -2,20 +2,17 @@ FROM rockylinux:8
 
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
-# Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
-
-# Install development tools
-RUN yum -y module install nodejs:20
+# Install node
+RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && \
+    source ~/.bashrc && \
+    nvm install 20.8.1 && \
+    node -v && npm -v
 
 # Install python3 for gyp
 RUN yum -y install python3
 
 # Upgrade gyp to a python3 compatible version
-RUN npm install -g node-gyp@latest
-
-# Install development tools
-RUN yum -y install nodejs
+RUN source ~/.bashrc && nvm use 20.8.1 && npm install -g node-gyp@latest
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packagingenv/rockylinux8/Dockerfile
+++ b/packagingenv/rockylinux8/Dockerfile
@@ -7,16 +7,12 @@ RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
 # Install node
 RUN yum -y module install nodejs:20
-RUN node --version
 
 # Install python3 for gyp
 RUN yum -y install python3
 
 # Upgrade gyp to a python3 compatible version
 RUN npm install -g node-gyp@latest
-
-# Install development tools
-#RUN yum -y install nodejs:20.1.1
 
 # Downgrade npm
 RUN npm install -g npm@6

--- a/packagingenv/rockylinux8/Dockerfile
+++ b/packagingenv/rockylinux8/Dockerfile
@@ -3,7 +3,7 @@ FROM rockylinux:8
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
 # Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
+RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install development tools
 RUN yum -y module install nodejs:10

--- a/packagingenv/rockylinux8/Dockerfile
+++ b/packagingenv/rockylinux8/Dockerfile
@@ -2,9 +2,6 @@ FROM rockylinux:8
 
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
-# Add NodeSource repo
-#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
-
 # Install node
 RUN yum -y module install nodejs:20
 

--- a/packagingenv/rockylinux8/Dockerfile
+++ b/packagingenv/rockylinux8/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install development tools
-RUN yum -y module install nodejs:10
+RUN yum -y module install nodejs:20
 
 # Install python3 for gyp
 RUN yum -y install python3

--- a/packagingenv/rockylinux8/Dockerfile
+++ b/packagingenv/rockylinux8/Dockerfile
@@ -2,17 +2,20 @@ FROM rockylinux:8
 
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
+# Add NodeSource repo
+RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
+
 # Install node
-RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && \
-    source ~/.bashrc && \
-    nvm install 20.8.1 && \
-    node -v && npm -v
+RUN yum -y module install nodejs:20.1.1
 
 # Install python3 for gyp
 RUN yum -y install python3
 
 # Upgrade gyp to a python3 compatible version
-RUN source ~/.bashrc && nvm use 20.8.1 && npm install -g node-gyp@latest
+RUN npm install -g node-gyp@latest
+
+# Install development tools
+RUN yum -y install nodejs:20.1.1
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packagingenv/rockylinux8/Dockerfile
+++ b/packagingenv/rockylinux8/Dockerfile
@@ -3,10 +3,11 @@ FROM rockylinux:8
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
 
 # Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
+#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install node
-RUN yum -y module install nodejs:20.1.1
+RUN yum -y module install nodejs:20
+RUN node --version
 
 # Install python3 for gyp
 RUN yum -y install python3
@@ -15,7 +16,10 @@ RUN yum -y install python3
 RUN npm install -g node-gyp@latest
 
 # Install development tools
-RUN yum -y install nodejs:20.1.1
+#RUN yum -y install nodejs:20.1.1
+
+# Downgrade npm
+RUN npm install -g npm@6
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packagingenv/rockylinux9/Dockerfile
+++ b/packagingenv/rockylinux9/Dockerfile
@@ -1,10 +1,8 @@
 FROM rockylinux:9
 
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
-RUN yum -y install systemd-rpm-macros
 
-# Add NodeSource repo
-#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
+RUN yum -y install systemd-rpm-macros
 
 # Install node
 RUN yum -y module install nodejs:20

--- a/packagingenv/rockylinux9/Dockerfile
+++ b/packagingenv/rockylinux9/Dockerfile
@@ -1,6 +1,7 @@
 FROM rockylinux:9
 
 RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
+RUN yum -y install systemd-rpm-macros
 
 # Add NodeSource repo
 #RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -

--- a/packagingenv/rockylinux9/Dockerfile
+++ b/packagingenv/rockylinux9/Dockerfile
@@ -1,0 +1,25 @@
+FROM rockylinux:9
+
+RUN yum -y install gcc-c++ make git libicu-devel rpmdevtools
+
+# Add NodeSource repo
+#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
+
+# Install node
+RUN yum -y module install nodejs:20
+RUN node --version
+
+# Install python3 for gyp
+RUN yum -y install python3
+
+# Upgrade gyp to a python3 compatible version
+RUN npm install -g node-gyp@latest
+
+# Install development tools
+#RUN yum -y install nodejs:20.1.1
+
+# Downgrade npm
+RUN npm install -g npm@6
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packagingenv/rockylinux9/docker-entrypoint.sh
+++ b/packagingenv/rockylinux9/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+operation="${1:-build}"
+
+case "$operation" in
+pull)
+  ;;
+build)
+  rpmbuild -bb rpm/st2chatops.spec
+  cp ../*.rpm $ARTIFACT_DIR
+  ;;
+*)
+  [[ $# -gt 0 ]] && exec "$@"
+  ;;
+esac

--- a/rpm/st2chatops.spec
+++ b/rpm/st2chatops.spec
@@ -8,7 +8,7 @@
 Name:           st2chatops
 Version:        %{version}
 Release:        %{release}
-Requires:       nodejs >= 2:20.0
+Requires:       nodejs >= 20.0
 
 Summary:        St2Chatops - StackStorm ChatOps
 
@@ -29,6 +29,9 @@ Prefix:         /opt/stackstorm/chatops
 Requires: /bin/bash
 Requires: /bin/sh
 Requires: /usr/bin/env
+%endif
+%if 0%{?rhel} >= 9
+BuildRequires: systemd-rpm-macros
 %endif
 
 # Cat debian/package.dirs, set buildroot prefix and create directories.

--- a/rpm/st2chatops.spec
+++ b/rpm/st2chatops.spec
@@ -8,7 +8,7 @@
 Name:           st2chatops
 Version:        %{version}
 Release:        %{release}
-Requires:       nodejs >= 2:10.0, nodejs < 2:15.0
+Requires:       nodejs >= 2:20.0
 
 Summary:        St2Chatops - StackStorm ChatOps
 

--- a/testingenv/Dockerfile.template
+++ b/testingenv/Dockerfile.template
@@ -2,9 +2,6 @@ FROM {{ dist }}:{{ version }}
 
 {% if dist in ('centos', 'fedora', 'rockylinux') -%}
 
-# Add NodeSource repo
-#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
-
 # Install development tools
 RUN yum -y module install nodejs:20
 

--- a/testingenv/Dockerfile.template
+++ b/testingenv/Dockerfile.template
@@ -3,10 +3,10 @@ FROM {{ dist }}:{{ version }}
 {% if dist in ('centos', 'fedora', 'rockylinux') -%}
 
 # Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
+#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install development tools
-RUN yum -y install nodejs
+RUN yum -y module install nodejs:20
 
 {% else -%}
 

--- a/testingenv/Dockerfile.template
+++ b/testingenv/Dockerfile.template
@@ -3,7 +3,7 @@ FROM {{ dist }}:{{ version }}
 {% if dist in ('centos', 'fedora', 'rockylinux') -%}
 
 # Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
+RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install development tools
 RUN yum -y install nodejs

--- a/testingenv/focal/Dockerfile
+++ b/testingenv/focal/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get clean && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install curl gnupg
 
 # Add NodeSource repo
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
 # Install node
 RUN apt-get update && \

--- a/testingenv/rockylinux8/Dockerfile
+++ b/testingenv/rockylinux8/Dockerfile
@@ -1,10 +1,13 @@
 FROM rockylinux:8
 
 # Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
+#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install development tools
-RUN yum -y install nodejs
+RUN yum -y module install nodejs:20
+
+# Downgrade npm
+RUN npm install -g npm@6
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/testingenv/rockylinux8/Dockerfile
+++ b/testingenv/rockylinux8/Dockerfile
@@ -1,8 +1,5 @@
 FROM rockylinux:8
 
-# Add NodeSource repo
-#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
-
 # Install development tools
 RUN yum -y module install nodejs:20 
 

--- a/testingenv/rockylinux8/Dockerfile
+++ b/testingenv/rockylinux8/Dockerfile
@@ -1,7 +1,7 @@
 FROM rockylinux:8
 
 # Add NodeSource repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
+RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install development tools
 RUN yum -y install nodejs

--- a/testingenv/rockylinux8/Dockerfile
+++ b/testingenv/rockylinux8/Dockerfile
@@ -4,7 +4,7 @@ FROM rockylinux:8
 #RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install development tools
-RUN yum -y module install nodejs:20
+RUN yum -y module install nodejs:20 
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/testingenv/rockylinux9/Dockerfile
+++ b/testingenv/rockylinux9/Dockerfile
@@ -4,7 +4,7 @@ FROM rockylinux:9
 #RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
 
 # Install development tools
-RUN yum -y module install nodejs:20
+RUN yum -y module install nodejs:20 
 
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/testingenv/rockylinux9/Dockerfile
+++ b/testingenv/rockylinux9/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:8
+FROM rockylinux:9
 
 # Add NodeSource repo
 #RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -

--- a/testingenv/rockylinux9/Dockerfile
+++ b/testingenv/rockylinux9/Dockerfile
@@ -1,8 +1,5 @@
 FROM rockylinux:9
 
-# Add NodeSource repo
-#RUN curl --silent --location https://rpm.nodesource.com/setup_20.x | bash -
-
 # Install development tools
 RUN yum -y module install nodejs:20 
 

--- a/testingenv/rockylinux9/docker-entrypoint.sh
+++ b/testingenv/rockylinux9/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+operation="${1:-test}"
+
+case "$operation" in
+pull)
+  ;;
+test)
+  yum install -y $ARTIFACT_DIR/*.rpm
+  cd /opt/stackstorm/chatops
+  sed -i.bak -r "s/^# (export HUBOT_ADAPTER=slack)/\1/" st2chatops.env
+  sed -i.bak -r "s/^# (export HUBOT_SLACK_TOKEN.).*/\1$SLACK_TOKEN/" st2chatops.env
+  sed -i.bak -r "s/^(export ST2_AUTH_USERNAME.).*/\1$ST2_USERNAME/" st2chatops.env
+  sed -i.bak -r "s/^(export ST2_AUTH_PASSWORD.).*/\1$ST2_PASSWORD/" st2chatops.env
+  bin/hubot &> /tmp/hubot.log &
+  sleep 15
+  cat /tmp/hubot.log
+  grep -rq "INFO Connected to Slack RTM" /tmp/hubot.log && \
+  grep -rq "INFO [[:digit:]]\+ commands are loaded" /tmp/hubot.log
+  exit $?
+  ;;
+*)
+  [[ $# -gt 0 ]] && exec "$@"
+  ;;
+esac


### PR DESCRIPTION
Install node20 - from AppStream on EL distributions and node source on focal
Update dependencies to be node >=20 on packages
Add build for EL9
Kept on npm 6 to avoid the CI needing to login to npm to rebuild the npm-shrinkwrap.json. npm upgrade can be performed under separate PR.